### PR TITLE
Fix:  Twig_Function abstract class By new Twig_SimpleFunction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ composer.lock
 
 test/app/cache
 test/app/logs
+
+
+.idea

--- a/Twig/GridExtension.php
+++ b/Twig/GridExtension.php
@@ -39,10 +39,10 @@ final class GridExtension extends \Twig_Extension
     public function getFunctions(): array
     {
         return [
-            new \Twig_Function('sylius_grid_render', [$this->gridHelper, 'renderGrid'], ['is_safe' => ['html']]),
-            new \Twig_Function('sylius_grid_render_field', [$this->gridHelper, 'renderField'], ['is_safe' => ['html']]),
-            new \Twig_Function('sylius_grid_render_action', [$this->gridHelper, 'renderAction'], ['is_safe' => ['html']]),
-            new \Twig_Function('sylius_grid_render_filter', [$this->gridHelper, 'renderFilter'], ['is_safe' => ['html']]),
+            new \Twig_SimpleFunction('sylius_grid_render', [$this->gridHelper, 'renderGrid'], ['is_safe' => ['html']]),
+            new \Twig_SimpleFunction('sylius_grid_render_field', [$this->gridHelper, 'renderField'], ['is_safe' => ['html']]),
+            new \Twig_SimpleFunction('sylius_grid_render_action', [$this->gridHelper, 'renderAction'], ['is_safe' => ['html']]),
+            new \Twig_SimpleFunction('sylius_grid_render_filter', [$this->gridHelper, 'renderFilter'], ['is_safe' => ['html']]),
         ];
     }
 }


### PR DESCRIPTION
Twig_Function abstract class By new Twig_SimpleFunction
Abtract class can not be instantiate