### PR TITLE
Fix filtering entities with multiple values

### DIFF
--- a/src/Bundle/Tests/Functional/GridApiTest.php
+++ b/src/Bundle/Tests/Functional/GridApiTest.php
@@ -104,10 +104,22 @@ final class GridApiTest extends JsonApiTestCase
     {
         $authorId = $this->data['author_michael_crichton']->getId();
 
-        $this->client->request('GET', sprintf('/books/?criteria[author]=%d', $authorId));
+        $this->client->request('GET', sprintf('/books/?criteria[author][]=%d', $authorId));
 
         $this->assertCount(2, $this->getItemsFromCurrentResponse());
         $this->assertSame('Jurassic Park', $this->getFirstItemFromCurrentResponse()['title']);
+    }
+
+    /** @test */
+    public function it_filters_books_by_authors(): void
+    {
+        $firstAuthorId = $this->data['author_michael_crichton']->getId();
+        $secondAuthorId = $this->data['author_john_watson']->getId();
+
+        $this->client->request('GET', sprintf('/books/?criteria[author][]=%d&criteria[author][]=%d', $firstAuthorId, $secondAuthorId));
+
+        $this->assertCount(3, $this->getItemsFromCurrentResponse());
+        $this->assertSame('A Study in Scarlet', $this->getFirstItemFromCurrentResponse()['title']);
     }
 
     /** @test */

--- a/src/Bundle/test/app/config/grids.yml
+++ b/src/Bundle/test/app/config/grids.yml
@@ -12,6 +12,7 @@ sylius_grid:
                     type: entity
                     form_options:
                         class: AppBundle\Entity\Author
+                        multiple: true
                 nationality:
                     type: entity
                     options:

--- a/src/Component/Filter/EntityFilter.php
+++ b/src/Component/Filter/EntityFilter.php
@@ -27,13 +27,16 @@ final class EntityFilter implements FilterInterface
             return;
         }
 
+        $values = is_array($data) ? $data : [$data];
         $fields = $options['fields'] ?? [$name];
 
         $expressionBuilder = $dataSource->getExpressionBuilder();
 
         $expressions = [];
         foreach ($fields as $field) {
-            $expressions[] = $expressionBuilder->equals($field, $data);
+            foreach ($values as $value) {
+                $expressions[] = $expressionBuilder->equals($field, $value);
+            }
         }
 
         $dataSource->restrict($expressionBuilder->orX(...$expressions));

--- a/src/Component/spec/Filter/EntityFilterSpec.php
+++ b/src/Component/spec/Filter/EntityFilterSpec.php
@@ -40,6 +40,21 @@ final class EntityFilterSpec extends ObjectBehavior
         $this->apply($dataSource, 'entity', '7', []);
     }
 
+    function it_filters_with_multiple_ids(
+        DataSourceInterface $dataSource,
+        ExpressionBuilderInterface $expressionBuilder
+    ): void {
+        $dataSource->getExpressionBuilder()->willReturn($expressionBuilder);
+
+        $expressionBuilder->equals('entity', '4')->willReturn('EXPR1');
+        $expressionBuilder->equals('entity', '2')->willReturn('EXPR2');
+        $expressionBuilder->orX('EXPR1', 'EXPR2')->willReturn('EXPR');
+
+        $dataSource->restrict('EXPR')->shouldBeCalled();
+
+        $this->apply($dataSource, 'entity', ['4', '2'], []);
+    }
+
     function it_does_not_filters_when_data_id_is_not_defined(
         DataSourceInterface $dataSource,
         ExpressionBuilderInterface $expressionBuilder


### PR DESCRIPTION
It fixes the entity filter when you add "multiple" on form options.

```
filters:
    partner:
        type: entity
        [..]
        form_options:
            [..]
            multiple: true
```