### PR TITLE
[WIP] Fix SQL join with existing alias

### DIFF
--- a/src/Bundle/Tests/DataFixtures/ORM/fixtures.yml
+++ b/src/Bundle/Tests/DataFixtures/ORM/fixtures.yml
@@ -15,15 +15,35 @@ AppBundle\Entity\Author:
         name: "<firstName()> <lastName()>"
         nationality: "@nationality_english"
 
+AppBundle\Entity\Attribute:
+    attribute_size_pocket:
+        code: "size"
+        value: "Pocket"
+    attribute_size_hardcover:
+        code: "size"
+        value: "Hardcover"
+    attribute_condition_good:
+        code: "condition"
+        value: "Good"
+    attribute_condition_bad:
+        code: "condition"
+        value: "Bad"
+
 AppBundle\Entity\Book:
     book_jurassic_park:
         title: "Jurassic Park"
         author: "@author_michael_crichton"
         price: "@price_1"
+        attributes:
+            - "@attribute_size_pocket"
+            - "@attribute_condition_good"
     book_the_lost_world:
         title: "The Lost World"
         author: "@author_michael_crichton"
         price: "@price_2"
+        attributes:
+            - "@attribute_size_hardcover"
+            - "@attribute_condition_bad"
     book_study_in_scarlet:
         title: "A Study in Scarlet"
         author: "@author_john_watson"

--- a/src/Bundle/Tests/Functional/GridApiTest.php
+++ b/src/Bundle/Tests/Functional/GridApiTest.php
@@ -133,6 +133,30 @@ final class GridApiTest extends JsonApiTestCase
     }
 
     /** @test */
+    public function it_filters_books_by_size_alone(): void
+    {
+        $sizeValue = $this->data['attribute_size_pocket']->getValue();
+        var_dump($sizeValue);
+
+        $this->client->request('GET', sprintf('/books/?criteria[size][type]=equal&criteria[size][value]=%s', $sizeValue));
+
+        $this->assertCount(1, $this->getItemsFromCurrentResponse());
+        $this->assertSame('Jurassic Park', $this->getFirstItemFromCurrentResponse()['title']);
+    }
+
+    /** @test */
+    public function it_filters_books_by_size_and_condition(): void
+    {
+        $sizeValue = $this->data['attribute_size_pocket']->getValue();
+        $conditionValue = $this->data['attribute_condition_good']->getValue();
+
+        $this->client->request('GET', sprintf('/books/?criteria[size][type]=equal&criteria[size][value]=%s&criteria[condition][type]=equal&criteria[condition][value]=%s', $sizeValue, $conditionValue));
+
+        $this->assertCount(1, $this->getItemsFromCurrentResponse());
+        $this->assertSame('Jurassic Park', $this->getFirstItemFromCurrentResponse()['title']);
+    }
+
+    /** @test */
     public function it_sorts_books_ascending_by_author(): void
     {
         $this->client->request('GET', '/books/?sorting[author]=asc&limit=100');

--- a/src/Bundle/test/app/config/grids.yml
+++ b/src/Bundle/test/app/config/grids.yml
@@ -5,6 +5,8 @@ sylius_grid:
                 name: doctrine/orm
                 options:
                     class: AppBundle\Entity\Book
+                    repository:
+                        method: createListQueryBuilder
             filters:
                 title:
                     type: string
@@ -22,6 +24,14 @@ sylius_grid:
                     type: string
                     options:
                         fields: [price.currencyCode]
+                size:
+                    type: string
+                    options:
+                        fields: [size.value]
+                condition:
+                    type: string
+                    options:
+                        fields: [condition.value]
             sorting:
                 title: asc
             fields:

--- a/src/Bundle/test/app/config/resources.yml
+++ b/src/Bundle/test/app/config/resources.yml
@@ -5,6 +5,10 @@ sylius_resource:
                 model: AppBundle\Entity\Book
                 repository: AppBundle\Repository\BookRepository
 
+        app.attribute:
+            classes:
+                model: AppBundle\Entity\Attribute
+
         app.author:
             classes:
                 model: AppBundle\Entity\Author

--- a/src/Bundle/test/src/AppBundle/Entity/Attribute.php
+++ b/src/Bundle/test/src/AppBundle/Entity/Attribute.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace AppBundle\Entity;
+
+use Sylius\Component\Resource\Model\ResourceInterface;
+
+class Attribute implements ResourceInterface
+{
+    /** @var int|null */
+    private $id;
+
+    /** @var string|null */
+    private $code;
+
+    /** @var string|null */
+    private $value;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getCode(): ?string
+    {
+        return $this->code;
+    }
+
+    public function setCode(?string $code): void
+    {
+        $this->code = $code;
+    }
+
+    public function getValue(): ?string
+    {
+        return $this->value;
+    }
+
+    public function setValue(?string $value): void
+    {
+        $this->value = $value;
+    }
+}

--- a/src/Bundle/test/src/AppBundle/Entity/Book.php
+++ b/src/Bundle/test/src/AppBundle/Entity/Book.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace AppBundle\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Sylius\Component\Resource\Model\ResourceInterface;
 
 class Book implements ResourceInterface
@@ -28,6 +30,14 @@ class Book implements ResourceInterface
 
     /** @var Price|null */
     private $price;
+
+    /** @var Collection&Attribute[] */
+    private $attributes;
+
+    public function __construct()
+    {
+        $this->attributes = new ArrayCollection();
+    }
 
     public function getId(): ?int
     {
@@ -63,5 +73,23 @@ class Book implements ResourceInterface
     public function setPrice(Price $price): void
     {
         $this->price = $price;
+    }
+
+    public function addAttribute(Attribute $attribute): void
+    {
+        $this->attributes->add($attribute);
+    }
+
+    public function removeAttribute(Attribute $attribute): void
+    {
+        $this->attributes->removeElement($attribute);
+    }
+
+    /**
+     * @return Collection&Book[]
+     */
+    public function getAttributes(): Collection
+    {
+        return $this->attributes;
     }
 }

--- a/src/Bundle/test/src/AppBundle/Repository/BookRepository.php
+++ b/src/Bundle/test/src/AppBundle/Repository/BookRepository.php
@@ -20,6 +20,15 @@ use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
 
 final class BookRepository extends EntityRepository
 {
+    public function createListQueryBuilder(): QueryBuilder
+    {
+        return $this->createQueryBuilder('b')
+            ->leftJoin('b.attributes', 'size', Join::WITH, 'size.code = :sizeCode')
+            ->leftJoin('b.attributes', 'condition', Join::WITH, 'condition.code = :conditionCode')
+            ->setParameter(':sizeCode', 'size')
+            ->setParameter(':conditionCode', 'condition');
+    }
+
     public function createAmericanBooksQueryBuilder(): QueryBuilder
     {
         return $this->createQueryBuilder('b')

--- a/src/Bundle/test/src/AppBundle/Resources/config/doctrine/Attribute.orm.yml
+++ b/src/Bundle/test/src/AppBundle/Resources/config/doctrine/Attribute.orm.yml
@@ -1,0 +1,16 @@
+AppBundle\Entity\Attribute:
+    type: mappedSuperclass
+    table: app_attribute
+    id:
+        id:
+            type: integer
+            id: true
+            generator:
+                strategy: AUTO
+    fields:
+        code:
+            type: string
+            length: 255
+        value:
+            type: string
+            length: 255

--- a/src/Bundle/test/src/AppBundle/Resources/config/doctrine/Book.orm.yml
+++ b/src/Bundle/test/src/AppBundle/Resources/config/doctrine/Book.orm.yml
@@ -20,3 +20,10 @@ AppBundle\Entity\Book:
             joinColumn:
                 name: author_id
                 referencedColumnName: id
+            inversedBy: books
+    manyToMany:
+        attributes:
+            targetEntity: AppBundle\Entity\Attribute
+            cascade: ["all"]
+            JoinTable:
+                name: app_book_attribute

--- a/src/Bundle/test/src/AppBundle/Resources/config/serializer/Entity.Attribute.yml
+++ b/src/Bundle/test/src/AppBundle/Resources/config/serializer/Entity.Attribute.yml
@@ -1,16 +1,12 @@
-AppBundle\Entity\Book:
+AppBundle\Entity\Attribute:
     exclusion_policy: ALL
     properties:
         id:
             expose: true
             type: integer
-        title:
+        code:
             expose: true
             type: string
-        author:
+        value:
             expose: true
-        price:
-            expose: true
-        attributes:
-            expose: true
-            type: array
+            type: string


### PR DESCRIPTION
When you add two joins with same resource and 2 aliases, the where condition is wrong.
It's a common case when you filters your products grid with attribute values. I added a simplified example with book attributes.

DQL with the PHPunit scenario **it_filters_books_by_size_and_condition**
```
SELECT b
FROM AppBundle\Entity\Book b LEFT JOIN b.attributes size
WITH size.code = :sizeCode LEFT JOIN b.attributes condition
WITH condition.code = :conditionCode
WHERE size.value = :size_value AND size.value = :condition_value
ORDER BY b.title asc
```

This pull request doesn't fix nothing for now. It only adds the PHPunit test to expose the issue.