### PR TITLE
Add support for php 7.4 and symfony 4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,12 @@ language: php
 php:
     - 7.2
     - 7.3
+    - 7.4
 
 env:
     - SYMFONY_VERSION=3.4.*
     - SYMFONY_VERSION=4.3.*
+    - SYMFONY_VERSION=4.4.*
 
 cache:
     directories:

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
         "symfony/templating": "^3.4|^4.3"
     },
     "require-dev": {
-        "akeneo/phpspec-skip-example-extension": "^4.0",
         "doctrine/doctrine-bundle": "^1.3",
         "doctrine/orm": "^2.5",
         "doctrine/phpcr-odm": "^1.3",
@@ -43,7 +42,8 @@
         "matthiasnoback/symfony-config-test": "^4.0",
         "matthiasnoback/symfony-dependency-injection-test": "^3.0",
         "pagerfanta/pagerfanta": "^1.0|^2.0",
-        "phpspec/phpspec": "^5.0",
+        "pamil/phpspec-skip-example-extension": "^4.1",
+        "phpspec/phpspec": "^6.1",
         "phpstan/phpstan-phpunit": "^0.11",
         "phpstan/phpstan": "^0.11",
         "phpstan/phpstan-webmozart-assert": "^0.11",

--- a/src/Bundle/Doctrine/ORM/Driver.php
+++ b/src/Bundle/Doctrine/ORM/Driver.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\GridBundle\Doctrine\ORM;
 
+use Doctrine\ORM\EntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
-use Doctrine\ORM\EntityRepository;
 use Sylius\Component\Grid\Data\DataSourceInterface;
 use Sylius\Component\Grid\Data\DriverInterface;
 use Sylius\Component\Grid\Parameters;

--- a/src/Bundle/Doctrine/ORM/Driver.php
+++ b/src/Bundle/Doctrine/ORM/Driver.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\GridBundle\Doctrine\ORM;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
 use Doctrine\ORM\EntityRepository;
 use Sylius\Component\Grid\Data\DataSourceInterface;
 use Sylius\Component\Grid\Data\DriverInterface;

--- a/src/Bundle/spec/Doctrine/ORM/DriverSpec.php
+++ b/src/Bundle/spec/Doctrine/ORM/DriverSpec.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Bundle\GridBundle\Doctrine\ORM;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;

--- a/src/Bundle/spec/Doctrine/ORM/DriverSpec.php
+++ b/src/Bundle/spec/Doctrine/ORM/DriverSpec.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Bundle\GridBundle\Doctrine\ORM;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\GridBundle\Doctrine\ORM\DataSource;
 use Sylius\Component\Grid\Data\DriverInterface;

--- a/src/Component/composer.json
+++ b/src/Component/composer.json
@@ -23,6 +23,7 @@
         "php": "^7.2",
 
         "sylius/registry": "^1.2",
+        "symfony/event-dispatcher": "^3.4|^4.3",
         "webmozart/assert": "^1.1"
     },
     "require-dev": {

--- a/src/Component/composer.json
+++ b/src/Component/composer.json
@@ -26,7 +26,7 @@
         "webmozart/assert": "^1.1"
     },
     "require-dev": {
-        "phpspec/phpspec": "^5.0",
+        "phpspec/phpspec": "^6.1",
         "symfony/property-access": "^3.4|^4.1.1"
     },
     "autoload": {


### PR DESCRIPTION
Support for Symfony version 3.4 is not fixed because it will be removed in https://github.com/Sylius/SyliusGridBundle/pull/34