### PR TITLE
Fix event dispatcher deprecation

### DIFF
--- a/src/Component/Definition/ArrayToDefinitionConverter.php
+++ b/src/Component/Definition/ArrayToDefinitionConverter.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Component\Grid\Definition;
 
 use Sylius\Component\Grid\Event\GridDefinitionConverterEvent;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 final class ArrayToDefinitionConverter implements ArrayToDefinitionConverterInterface
 {
@@ -59,7 +59,7 @@ final class ArrayToDefinitionConverter implements ArrayToDefinitionConverterInte
             $grid->addActionGroup($this->convertActionGroup($name, $actionGroupConfiguration));
         }
 
-        $this->eventDispatcher->dispatch($this->getEventName($code), new GridDefinitionConverterEvent($grid));
+        $this->eventDispatcher->dispatch(new GridDefinitionConverterEvent($grid), $this->getEventName($code));
 
         return $grid;
     }

--- a/src/Component/Event/GridDefinitionConverterEvent.php
+++ b/src/Component/Event/GridDefinitionConverterEvent.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Component\Grid\Event;
 
 use Sylius\Component\Grid\Definition\Grid;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class GridDefinitionConverterEvent extends Event
 {

--- a/src/Component/spec/Definition/ArrayToDefinitionConverterSpec.php
+++ b/src/Component/spec/Definition/ArrayToDefinitionConverterSpec.php
@@ -22,7 +22,7 @@ use Sylius\Component\Grid\Definition\Field;
 use Sylius\Component\Grid\Definition\Filter;
 use Sylius\Component\Grid\Definition\Grid;
 use Sylius\Component\Grid\Event\GridDefinitionConverterEvent;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 final class ArrayToDefinitionConverterSpec extends ObjectBehavior
 {
@@ -94,7 +94,7 @@ final class ArrayToDefinitionConverterSpec extends ObjectBehavior
         $grid->addFilter($filter);
 
         $eventDispatcher
-            ->dispatch('sylius.grid.admin_tax_category', Argument::type(GridDefinitionConverterEvent::class))
+            ->dispatch(Argument::type(GridDefinitionConverterEvent::class), 'sylius.grid.admin_tax_category')
             ->shouldBeCalled()
         ;
 


### PR DESCRIPTION
User Deprecated: Calling the "Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch()" method with the event name as first argument is deprecated since Symfony 4.3, pass it second and provide the event object first instead.