### PR TITLE
Submit form only if criteria is available

### DIFF
--- a/src/Bundle/Renderer/TwigGridRenderer.php
+++ b/src/Bundle/Renderer/TwigGridRenderer.php
@@ -125,7 +125,9 @@ final class TwigGridRenderer implements GridRendererInterface
         );
 
         $criteria = $gridView->getParameters()->get('criteria', []);
-        $form->submit($criteria);
+        if ($criteria) {
+            $form->submit($criteria);
+        }
 
         return $this->twig->render($template, [
             'grid' => $gridView,

--- a/src/Bundle/Renderer/TwigGridRenderer.php
+++ b/src/Bundle/Renderer/TwigGridRenderer.php
@@ -125,7 +125,7 @@ final class TwigGridRenderer implements GridRendererInterface
         );
 
         $criteria = $gridView->getParameters()->get('criteria', []);
-        if ($criteria) {
+        if ([] !== $criteria) {
             $form->submit($criteria);
         }
 


### PR DESCRIPTION
Form submit is always called, so on overviews without criteria it does unnecessary validator calls (one per filter).