### PR TITLE
Fix sorting grids by nullable path

### DIFF
--- a/src/Bundle/Doctrine/ORM/ExpressionBuilder.php
+++ b/src/Bundle/Doctrine/ORM/ExpressionBuilder.php
@@ -216,7 +216,7 @@ final class ExpressionBuilder implements ExpressionBuilderInterface
                 }
             }
 
-            $this->queryBuilder->innerJoin($rootAndAssociationField, $associationAlias);
+            $this->queryBuilder->leftJoin($rootAndAssociationField, $associationAlias);
             $resolvedField = sprintf('%s.%s', $associationAlias, $remainder);
         }
 

--- a/src/Bundle/Tests/DataFixtures/ORM/fixtures.yml
+++ b/src/Bundle/Tests/DataFixtures/ORM/fixtures.yml
@@ -11,6 +11,8 @@ AppBundle\Entity\Author:
     author_john_watson:
         name: "John Watson"
         nationality: "@nationality_english"
+    author_random:
+        name: "Random Author Without Nationality"
     author_{1..19}:
         name: "<firstName()> <lastName()>"
         nationality: "@nationality_english"

--- a/src/Bundle/Tests/Functional/GridApiTest.php
+++ b/src/Bundle/Tests/Functional/GridApiTest.php
@@ -229,6 +229,23 @@ final class GridApiTest extends JsonApiTestCase
         $this->assertSame('A Study in Scarlet', $this->getFirstItemFromCurrentResponse()['title']);
     }
 
+    /** @test */
+    public function x(): void
+    {
+        $this->client->request('GET', '/authors/');
+        $totalItemsCountBeforeSorting = $this->getTotalItemsCountFromCurrentResponse();
+
+        $this->client->request('GET', '/authors/?sorting[nationality]=desc');
+        $totalItemsCountAfterSorting = $this->getTotalItemsCountFromCurrentResponse();
+
+        $this->assertSame($totalItemsCountBeforeSorting, $totalItemsCountAfterSorting);
+    }
+
+    private function getTotalItemsCountFromCurrentResponse(): int
+    {
+        return json_decode($this->client->getResponse()->getContent(), true)['total'];
+    }
+
     private function getItemsFromCurrentResponse(): array
     {
         return json_decode($this->client->getResponse()->getContent(), true)['_embedded']['items'];

--- a/src/Bundle/Tests/Functional/GridApiTest.php
+++ b/src/Bundle/Tests/Functional/GridApiTest.php
@@ -230,7 +230,7 @@ final class GridApiTest extends JsonApiTestCase
     }
 
     /** @test */
-    public function x(): void
+    public function it_includes_all_rows_even_when_sorting_by_a_nullable_path(): void
     {
         $this->client->request('GET', '/authors/');
         $totalItemsCountBeforeSorting = $this->getTotalItemsCountFromCurrentResponse();

--- a/src/Bundle/Tests/Responses/Expected/authors_grid.json
+++ b/src/Bundle/Tests/Responses/Expected/authors_grid.json
@@ -2,7 +2,7 @@
     "page": 1,
     "limit": 10,
     "pages": 3,
-    "total": 21,
+    "total": 22,
     "_links": {
         "self": {
             "href": "\/authors\/?page=1&limit=10"

--- a/src/Bundle/test/app/config/grids.yml
+++ b/src/Bundle/test/app/config/grids.yml
@@ -67,6 +67,11 @@ sylius_grid:
                     type: string
                     label: Name
                     sortable: ~
+                nationality:
+                    type: string
+                    label: Name
+                    sortable: nationality.name
+                    path: nationality.name
             limits: [10, 5, 15]
 
         app_book_by_american_authors:

--- a/src/Bundle/test/src/AppBundle/Resources/config/doctrine/Author.orm.yml
+++ b/src/Bundle/test/src/AppBundle/Resources/config/doctrine/Author.orm.yml
@@ -22,4 +22,5 @@ AppBundle\Entity\Author:
             joinColumn:
                 name: nationality_id
                 referencedColumnName: id
+                nullable: true
             cascade: ["all"]


### PR DESCRIPTION
#### Background

- Author can have a nationality assigned, but does not have to
- Nationality have a name
- There are three authors with nationality assigned and two without

#### Actual behaviour

When I sort by nationality, it shows only the three authors that have a nationality assigned

#### Expected behaviour

When I sort by nationality, I would expect it to include all five authors, treating the ones without the nationality as it would be empty