### PR TITLE
[WIP] Init make sylius grid command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "symfony/framework-bundle": "^4.4|^5.0",
         "symfony/http-kernel": "^4.4|^5.0",
         "symfony/options-resolver": "^4.4|^5.0",
-        "symfony/property-access": "^4.4|^5.0"
+        "symfony/property-access": "^4.4|^5.0",
+        "symfony/maker-bundle": "^1.14"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.3",

--- a/src/Bundle/Maker/MakeGrid.php
+++ b/src/Bundle/Maker/MakeGrid.php
@@ -299,6 +299,7 @@ final class MakeGrid extends AbstractMaker
             $this->gridHelper->getFilterIds()
         );
         $filterData['type'] = $io->askQuestion($choiceQuestion);
+        $filterData['label'] = $io->ask('Enter the filter label', null);
 
         $choiceQuestion = new ChoiceQuestion(
             'Enter the filter options (Leave blank if you have no options',

--- a/src/Bundle/Maker/MakeGrid.php
+++ b/src/Bundle/Maker/MakeGrid.php
@@ -424,7 +424,7 @@ final class MakeGrid extends AbstractMaker
         $resource = $this->resourceHelper->getResourceNameFromAlias($resourceAlias);
         $filename = $resource.'.yaml';
 
-        return sprintf('%s/%s/%s', $this->projectDir.'/config/packages/grids', $section, $filename);
+        return sprintf('%s/%s/%s', $this->projectDir.'/config/grids', $section, $filename);
     }
 
     private function filterSortableFields(array $fields): array

--- a/src/Bundle/Maker/MakeGrid.php
+++ b/src/Bundle/Maker/MakeGrid.php
@@ -166,7 +166,7 @@ final class MakeGrid extends AbstractMaker
             $questionText = 'Add another field? Enter the field name (or press <return> to stop adding fields)';
         }
 
-        $fieldName = $io->ask($questionText, null, function ($name) {
+        $fieldName = $io->ask($questionText, null, function ($name): ?string {
             // allow it to be empty
             if (!$name) {
                 return $name;

--- a/src/Bundle/Maker/MakeGrid.php
+++ b/src/Bundle/Maker/MakeGrid.php
@@ -8,6 +8,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 declare(strict_types=1);
 
 namespace Sylius\Bundle\GridBundle\Maker;
@@ -386,7 +387,7 @@ final class MakeGrid extends AbstractMaker
             'driver' => [
                 'name' => 'doctrine/orm',
                 'options' => [
-                    'class' => '"%'.$modelClass.'%"',
+                    'class' => '"%' . $modelClass . '%"',
                 ],
             ],
         ];
@@ -423,9 +424,9 @@ final class MakeGrid extends AbstractMaker
     private function getGridConfigDir(string $resourceAlias, string $section)
     {
         $resource = $this->resourceHelper->getResourceNameFromAlias($resourceAlias);
-        $filename = $resource.'.yaml';
+        $filename = $resource . '.yaml';
 
-        return sprintf('%s/%s/%s', $this->projectDir.'/config/grids', $section, $filename);
+        return sprintf('%s/%s/%s', $this->projectDir . '/config/grids', $section, $filename);
     }
 
     private function filterSortableFields(array $fields): array

--- a/src/Bundle/Maker/MakeGrid.php
+++ b/src/Bundle/Maker/MakeGrid.php
@@ -72,7 +72,7 @@ final class MakeGrid extends AbstractMaker
     {
         $command
             ->setDescription('Creates a new grid')
-            ->addArgument('section', InputArgument::REQUIRED, 'Section of the grid (backend or frontend)')
+            ->addArgument('section', InputArgument::REQUIRED, 'Section of the grid (backend, frontend, admin, api)')
             ->addArgument('resource', InputArgument::REQUIRED, 'Resource alias of the grid')
         ;
 
@@ -83,13 +83,7 @@ final class MakeGrid extends AbstractMaker
     public function interact(InputInterface $input, ConsoleStyle $io, Command $command)
     {
         if (!$input->getArgument('section')) {
-            $question = new ChoiceQuestion(
-                'Please select a section for your grid',
-                ['backend', 'frontend'],
-                0
-            );
-
-            $section = $io->askQuestion($question);
+            $section = $io->ask('Enter a section for you grid (backend, frontend, admin, api)', 'backend');
 
             $input->setArgument('section', $section);
         }

--- a/src/Bundle/Maker/MakeGrid.php
+++ b/src/Bundle/Maker/MakeGrid.php
@@ -1,0 +1,285 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Sylius\Bundle\GridBundle\Maker;
+
+use Sylius\Component\Grid\Maker\Filter\Helper\GridHelperInterface;
+use Sylius\Component\Grid\Maker\Filter\ResourceHelperInterface;
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Yaml\Yaml;
+use Webmozart\Assert\Assert;
+
+final class MakeGrid extends AbstractMaker
+{
+    public static $defaultActionTypes = [
+        'main' => [
+            'create' => 'create',
+        ],
+        'item' => [
+            'update' => 'update',
+            'delete' => 'delete',
+        ],
+        'bulk' => [
+            'delete' => 'delete',
+        ],
+    ];
+
+    /** @var string */
+    private $projectDir;
+
+    /** @var ResourceHelperInterface */
+    private $resourceHelper;
+
+    /** @var GridHelperInterface */
+    private $gridHelper;
+
+    /** @var Filesystem */
+    private $fileSystem;
+
+    public function __construct(string $projectDir, ResourceHelperInterface $resourceHelper, GridHelperInterface $gridHelper)
+    {
+        $this->projectDir = $projectDir;
+        $this->resourceHelper = $resourceHelper;
+        $this->gridHelper = $gridHelper;
+
+        $this->fileSystem = new Filesystem();
+    }
+
+    public static function getCommandName(): string
+    {
+        return 'make:sylius-grid';
+    }
+
+    public function configureCommand(Command $command, InputConfiguration $inputConfig)
+    {
+        $command
+            ->setDescription('Creates a new grid')
+            ->addArgument('section', InputArgument::REQUIRED, 'Section of the grid (backend or frontend)')
+            ->addArgument('resource', InputArgument::REQUIRED, 'Resource alias of the grid')
+        ;
+
+        $inputConfig->setArgumentAsNonInteractive('resource');
+        $inputConfig->setArgumentAsNonInteractive('section');
+    }
+
+    public function interact(InputInterface $input, ConsoleStyle $io, Command $command)
+    {
+        if (!$input->getArgument('section')) {
+            $question = new ChoiceQuestion(
+                'Please select a section for your grid',
+                ['backend', 'frontend'],
+                0
+            );
+
+            $section = $io->askQuestion($question);
+
+            $input->setArgument('section', $section);
+        }
+
+        if (!$input->getArgument('resource')) {
+            $aliases = $this->resourceHelper->getResourcesAliases();
+            $question = new ChoiceQuestion(
+                'Please select a resource for your grid',
+                array_combine($aliases, $aliases),
+                0
+            );
+            $question->setAutocompleterValues($aliases);
+
+            $resourceAlias = $io->askQuestion($question);
+
+            $input->setArgument('resource', $resourceAlias);
+        }
+
+        if ($resourceAlias = $input->getArgument('resource')) {
+            Assert::true($this->resourceHelper->isResourceAliasExist($resourceAlias), sprintf(
+                    'Resource with alias %s not found',
+                    $resourceAlias
+                )
+            );
+        }
+    }
+
+    public function configureDependencies(DependencyBuilder $dependencies)
+    {
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
+    {
+        $fields = [];
+        $isFirstField = true;
+        while (true) {
+            $newField = $this->askForNextField($io, $isFirstField);
+            $isFirstField = false;
+
+            if (null === $newField) {
+                break;
+            }
+
+            $fields = array_merge($fields, $newField);
+        }
+
+        $actions = [
+            'main' => [],
+            'item' => [],
+            'bulk' => [],
+        ];
+
+        foreach ($actions as $section => $data) {
+            $hasSectionAction = $io->confirm(sprintf('Do you have %s actions?', $section), true);
+
+            if ($hasSectionAction) {
+                $newActions = $this->askForNextAction($io, $section);
+                $actions[$section] = array_merge($actions[$section], $newActions);
+            } else {
+                unset($actions[$section]);
+            }
+        }
+
+        $this->generateGridConfigFile($input, $io, $generator, $fields, $actions);
+    }
+
+    private function askForNextField(ConsoleStyle $io, bool $isFirstField)
+    {
+        $io->writeln('');
+
+        if ($isFirstField) {
+            $questionText = 'New field name (press <return> to stop adding fields)';
+        } else {
+            $questionText = 'Add another field? Enter the field name (or press <return> to stop adding fields)';
+        }
+
+        $fieldName = $io->ask($questionText, null, function ($name) {
+            // allow it to be empty
+            if (!$name) {
+                return $name;
+            }
+
+            return $name;
+        });
+
+        if (!$fieldName) {
+            return null;
+        }
+
+        $fieldData = [];
+        $fieldData['type'] = $io->choice('Enter the field type', ['string', 'datetime', 'twig'], 'string');
+        $fieldData['label'] = $io->ask('Enter the field label', null);
+        $isSortable = $io->confirm('Is the field sortable?', true);
+
+        if ($isSortable) {
+            $fieldData['sortable'] = $io->ask('Enter the sortable path (leave blank to set the default value)', null);
+        }
+
+        if ('twig' === $fieldData['type']) {
+            $fieldData['options'] = [];
+            $fieldData['options']['template'] = $io->ask('Enter the twig template path', null);
+        }
+
+        if ('datetime' === $fieldData['type']) {
+            $fieldData['options'] = [];
+            $fieldData['options']['format'] = $io->ask('Enter the date format', 'Y-m-d H:i:s');
+        }
+
+        return [
+            $fieldName => $fieldData,
+        ];
+    }
+
+    private function askForNextAction(ConsoleStyle $io, string $section)
+    {
+        $io->writeln('');
+
+        $actionTypes = static::$defaultActionTypes[$section];
+
+        if (count($actionTypes) > 1) {
+            $choiceQuestion = new ChoiceQuestion(
+                'Enter the action types (coma-separated)',
+                static::$defaultActionTypes[$section],
+                implode(', ', static::$defaultActionTypes[$section])
+            );
+            $choiceQuestion->setMultiselect(true);
+            $choiceQuestion->setAutocompleterValues($actionTypes);
+            $actionTypes = $io->askQuestion($choiceQuestion);
+        }
+
+        $data = [];
+        foreach ($actionTypes as $type) {
+            $data[$type] = [
+                'type' => $type,
+            ];
+        }
+
+        return $data;
+    }
+
+    private function generateGridConfigFile(
+        InputInterface $input,
+        ConsoleStyle $io,
+        Generator $generator,
+        array $fields,
+        array $actions
+    ): void {
+        $section = $input->getArgument('section');
+        $resourceAlias = $input->getArgument('resource');
+        [$appName, $resourceName] = $this->resourceHelper->splitResourceAlias($resourceAlias);
+        $gridId = sprintf('%s_%s_%s', $appName, $section, $resourceName);
+
+        $gridConfigDir = $this->getGridConfigDir($resourceAlias, $section);
+        $modelClass = $this->resourceHelper->getResourceModelFromAlias($resourceAlias);
+
+        $gridData = [
+            'driver' => [
+                'name' => 'doctrine/orm',
+                'options' => [
+                    'class' => '"%'.$modelClass.'%"',
+                ],
+            ],
+        ];
+
+        if (count($fields) > 0) {
+            $gridData['fields'] = $fields;
+        }
+
+        if (count($actions) > 0) {
+            $gridData['actions'] = $actions;
+        }
+
+        $data = [
+            'sylius_grid' => [
+                'grids' => [
+                    $gridId => $gridData,
+                ],
+            ],
+        ];
+
+        $yaml = Yaml::dump($data, 10, 4, Yaml::DUMP_NULL_AS_TILDE);
+
+        $this->fileSystem->dumpFile($gridConfigDir, $yaml);
+    }
+
+    private function getGridConfigDir(string $resourceAlias, string $section)
+    {
+        $resource = $this->resourceHelper->getResourceNameFromAlias($resourceAlias);
+        $filename = $resource.'.yaml';
+
+        return sprintf('%s/%s/%s', $this->projectDir.'/config/packages/grids', $section, $filename);
+    }
+}

--- a/src/Bundle/Maker/MakeGrid.php
+++ b/src/Bundle/Maker/MakeGrid.php
@@ -91,19 +91,23 @@ final class MakeGrid extends AbstractMaker
 
         if (!$input->getArgument('resource')) {
             $aliases = $this->resourceHelper->getResourcesAliases();
+            /** @var array $choices */
+            $choices = array_combine($aliases, $aliases);
             $question = new ChoiceQuestion(
                 'Please select a resource for your grid',
-                array_combine($aliases, $aliases),
+                $choices,
                 0
             );
-            $question->setAutocompleterValues($aliases);
+            $question->setAutocompleterValues($choices);
 
             $resourceAlias = $io->askQuestion($question);
 
             $input->setArgument('resource', $resourceAlias);
         }
 
-        if ($resourceAlias = $input->getArgument('resource')) {
+        if (null !== $input->getArgument('resource')) {
+            /** @var string $resourceAlias */
+            $resourceAlias = $input->getArgument('resource');
             Assert::true($this->resourceHelper->isResourceAliasExist($resourceAlias), sprintf(
                     'Resource with alias %s not found',
                     $resourceAlias
@@ -223,6 +227,7 @@ final class MakeGrid extends AbstractMaker
     {
         $io->writeln('');
 
+        /** @var array $choices */
         $choices = array_combine($sortableFields, $sortableFields);
 
         $choiceQuestion = new ChoiceQuestion(
@@ -375,7 +380,9 @@ final class MakeGrid extends AbstractMaker
         array $actions,
         array $filters
     ): void {
+        /** @var string $section */
         $section = $input->getArgument('section');
+        /** @var string $resourceAlias */
         $resourceAlias = $input->getArgument('resource');
         [$appName, $resourceName] = $this->resourceHelper->splitResourceAlias($resourceAlias);
         $gridId = sprintf('%s_%s_%s', $appName, $section, $resourceName);

--- a/src/Bundle/Maker/MakeGrid.php
+++ b/src/Bundle/Maker/MakeGrid.php
@@ -30,7 +30,8 @@ use Webmozart\Assert\Assert;
 
 final class MakeGrid extends AbstractMaker
 {
-    public static $defaultActionTypes = [
+    /** @var array */
+    private const DEFAULT_ACTION_TYPES = [
         'main' => [
             'create' => 'create',
         ],
@@ -69,7 +70,7 @@ final class MakeGrid extends AbstractMaker
         return 'make:sylius-grid';
     }
 
-    public function configureCommand(Command $command, InputConfiguration $inputConfig)
+    public function configureCommand(Command $command, InputConfiguration $inputConfig): void
     {
         $command
             ->setDescription('Creates a new grid')
@@ -81,7 +82,7 @@ final class MakeGrid extends AbstractMaker
         $inputConfig->setArgumentAsNonInteractive('section');
     }
 
-    public function interact(InputInterface $input, ConsoleStyle $io, Command $command)
+    public function interact(InputInterface $input, ConsoleStyle $io, Command $command): void
     {
         if (!$input->getArgument('section')) {
             $section = $io->ask('Enter a section for you grid (backend, frontend, admin, api)', 'backend');
@@ -116,11 +117,11 @@ final class MakeGrid extends AbstractMaker
         }
     }
 
-    public function configureDependencies(DependencyBuilder $dependencies)
+    public function configureDependencies(DependencyBuilder $dependencies): void
     {
     }
 
-    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
         $fields = [];
         $isFirstField = true;
@@ -181,7 +182,12 @@ final class MakeGrid extends AbstractMaker
         $this->generateGridConfigFile($input, $io, $generator, $fields, $sortingFields, $actions, $filters);
     }
 
-    private function askForNextField(ConsoleStyle $io, bool $isFirstField)
+    /**
+     * @return (array|mixed)[][]|null
+     *
+     * @psalm-return array<mixed, array{type: mixed|string, label: mixed, sortable?: mixed, options?: array{template?: mixed, format?: mixed}}>|null
+     */
+    private function askForNextField(ConsoleStyle $io, bool $isFirstField): ?array
     {
         $io->writeln('');
 
@@ -191,7 +197,7 @@ final class MakeGrid extends AbstractMaker
             $questionText = 'Add another field? Enter the field name (or press <return> to stop adding fields)';
         }
 
-        $fieldName = $io->ask($questionText, null, function ($name): ?string {
+        $fieldName = $io->ask($questionText, null, function (string $name): ?string {
             return $name ?: null;
         });
 
@@ -223,7 +229,7 @@ final class MakeGrid extends AbstractMaker
         ];
     }
 
-    private function askForSortingFieldNames(ConsoleStyle $io, array $sortableFields)
+    private function askForSortingFieldNames(ConsoleStyle $io, array $sortableFields): array
     {
         $io->writeln('');
 
@@ -240,7 +246,7 @@ final class MakeGrid extends AbstractMaker
         return $io->askQuestion($choiceQuestion);
     }
 
-    private function askForSortingOrder(ConsoleStyle $io, string $fieldName)
+    private function askForSortingOrder(ConsoleStyle $io, string $fieldName): string
     {
         $io->writeln('');
 
@@ -253,17 +259,17 @@ final class MakeGrid extends AbstractMaker
         return $io->askQuestion($choiceQuestion);
     }
 
-    private function askForNextAction(ConsoleStyle $io, string $section)
+    private function askForNextAction(ConsoleStyle $io, string $section): array
     {
         $io->writeln('');
 
-        $actionTypes = static::$defaultActionTypes[$section];
+        $actionTypes = static::DEFAULT_ACTION_TYPES[$section];
 
         if (count($actionTypes) > 1) {
             $choiceQuestion = new ChoiceQuestion(
                 'Enter the action types (coma-separated)',
-                static::$defaultActionTypes[$section],
-                implode(', ', static::$defaultActionTypes[$section])
+                static::DEFAULT_ACTION_TYPES[$section],
+                implode(', ', static::DEFAULT_ACTION_TYPES[$section])
             );
             $choiceQuestion->setMultiselect(true);
             $choiceQuestion->setAutocompleterValues($actionTypes);
@@ -280,7 +286,12 @@ final class MakeGrid extends AbstractMaker
         return $data;
     }
 
-    private function askForNextFilter(ConsoleStyle $io, bool $isFirstFilter)
+    /**
+     * @return (array|mixed)[][]|null
+     *
+     * @psalm-return array<mixed, array{type: mixed, label: mixed, options: array<string, mixed>, form_options?: array}>|null
+     */
+    private function askForNextFilter(ConsoleStyle $io, bool $isFirstFilter): ?array
     {
         $io->writeln('');
 
@@ -290,7 +301,7 @@ final class MakeGrid extends AbstractMaker
             $questionText = 'Add another filter? Enter the filter name (or press <return> to stop adding fields)';
         }
 
-        $filterName = $io->ask($questionText, null, function ($name): ?string {
+        $filterName = $io->ask($questionText, null, function (string $name): ?string {
             return $name ?: null;
         });
 
@@ -346,7 +357,7 @@ final class MakeGrid extends AbstractMaker
         ];
     }
 
-    private function askForNextFormOption(ConsoleStyle $io, bool $isFirstFormOption)
+    private function askForNextFormOption(ConsoleStyle $io, bool $isFirstFormOption): ?array
     {
         $io->writeln('');
 
@@ -356,7 +367,7 @@ final class MakeGrid extends AbstractMaker
             $questionText = 'Add another form option? Enter the form option name (or press <return> to stop adding form options)';
         }
 
-        $formOptionName = $io->ask($questionText, null, function ($name): ?string {
+        $formOptionName = $io->ask($questionText, null, function (string $name): ?string {
             return $name ?: null;
         });
 
@@ -428,7 +439,7 @@ final class MakeGrid extends AbstractMaker
         $this->fileSystem->dumpFile($gridConfigDir, $yaml);
     }
 
-    private function getGridConfigDir(string $resourceAlias, string $section)
+    private function getGridConfigDir(string $resourceAlias, string $section): string
     {
         $resource = $this->resourceHelper->getResourceNameFromAlias($resourceAlias);
         $filename = $resource . '.yaml';

--- a/src/Component/Maker/Helper/GridHelper.php
+++ b/src/Component/Maker/Helper/GridHelper.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Maker\Helper;
+
+class GridHelper implements GridHelperInterface
+{
+    /** @var array */
+    private $syliusGridFilters;
+
+    public function __construct(array $syliusGridFilters)
+    {
+        $this->syliusGridFilters = $syliusGridFilters;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilterIds(): array
+    {
+        return array_keys($this->syliusGridFilters);
+    }
+}

--- a/src/Component/Maker/Helper/GridHelper.php
+++ b/src/Component/Maker/Helper/GridHelper.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Grid\Maker\Helper;
 
-class GridHelper implements GridHelperInterface
+final class GridHelper implements GridHelperInterface
 {
     /** @var array */
     private $syliusGridFilters;

--- a/src/Component/Maker/Helper/GridHelperInterface.php
+++ b/src/Component/Maker/Helper/GridHelperInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Maker\Helper;
+
+interface GridHelperInterface
+{
+    public function getFilterIds(): array;
+}

--- a/src/Component/Maker/Helper/ResourceHelper.php
+++ b/src/Component/Maker/Helper/ResourceHelper.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Maker\Helper;
+
+class ResourceHelper implements ResourceHelperInterface
+{
+    /** @var array */
+    private $syliusResources;
+
+    public function __construct(array $syliusResources)
+    {
+        $this->syliusResources = $syliusResources;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getResourcesAliases(): array
+    {
+        return array_keys($this->syliusResources);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getResourceModelFromAlias(string $resourceAlias): string
+    {
+        [$appName, $resourceName] = $this->splitResourceAlias($resourceAlias);
+
+        return sprintf('%s.model.%s.class', $appName, $resourceName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getResourceNameFromAlias(string $resourceAlias): string
+    {
+        return $this->splitResourceAlias($resourceAlias)[1];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function splitResourceAlias(string $resourceAlias): array
+    {
+        return explode('.', $resourceAlias);
+    }
+}

--- a/src/Component/Maker/Helper/ResourceHelper.php
+++ b/src/Component/Maker/Helper/ResourceHelper.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Grid\Maker\Helper;
 
-class ResourceHelper implements ResourceHelperInterface
+final class ResourceHelper implements ResourceHelperInterface
 {
     /** @var array */
     private $syliusResources;

--- a/src/Component/Maker/Helper/ResourceHelper.php
+++ b/src/Component/Maker/Helper/ResourceHelper.php
@@ -34,6 +34,14 @@ class ResourceHelper implements ResourceHelperInterface
     /**
      * {@inheritdoc}
      */
+    public function isResourceAliasExist(string $resourceAlias): bool
+    {
+        return in_array($resourceAlias, $this->getResourcesAliases());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getResourceModelFromAlias(string $resourceAlias): string
     {
         [$appName, $resourceName] = $this->splitResourceAlias($resourceAlias);

--- a/src/Component/Maker/Helper/ResourceHelperInterface.php
+++ b/src/Component/Maker/Helper/ResourceHelperInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Maker\Helper;
+
+interface ResourceHelperInterface
+{
+    public function getResourcesAliases(): array;
+
+    public function getResourceModelFromAlias(string $resourceAlias): string;
+
+    public function getResourceNameFromAlias(string $resourceAlias): string;
+
+    public function splitResourceAlias(string $resourceAlias): array;
+}

--- a/src/Component/Maker/Helper/ResourceHelperInterface.php
+++ b/src/Component/Maker/Helper/ResourceHelperInterface.php
@@ -17,6 +17,8 @@ interface ResourceHelperInterface
 {
     public function getResourcesAliases(): array;
 
+    public function isResourceAliasExist(string $resourceAlias): bool;
+
     public function getResourceModelFromAlias(string $resourceAlias): string;
 
     public function getResourceNameFromAlias(string $resourceAlias): string;

--- a/src/Component/spec/Maker/Helper/GridHelperSpec.php
+++ b/src/Component/spec/Maker/Helper/GridHelperSpec.php
@@ -5,7 +5,7 @@ namespace spec\Sylius\Component\Grid\Maker\Helper;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Grid\Maker\Helper\GridHelper;
 
-class GridHelperSpec extends ObjectBehavior
+final class GridHelperSpec extends ObjectBehavior
 {
     function let(): void
     {

--- a/src/Component/spec/Maker/Helper/GridHelperSpec.php
+++ b/src/Component/spec/Maker/Helper/GridHelperSpec.php
@@ -15,7 +15,7 @@ final class GridHelperSpec extends ObjectBehavior
         ]);
     }
 
-    function it_is_initializable()
+    function it_is_initializable(): void
     {
         $this->shouldHaveType(GridHelper::class);
     }

--- a/src/Component/spec/Maker/Helper/GridHelperSpec.php
+++ b/src/Component/spec/Maker/Helper/GridHelperSpec.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace spec\Sylius\Component\Grid\Maker\Helper;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Grid\Maker\Helper\GridHelper;
+
+class GridHelperSpec extends ObjectBehavior
+{
+    function let(): void
+    {
+        $this->beConstructedWith([
+            'string' => "@SyliusUi/Grid/Filter/string.html.twig",
+            'boolean' => "@SyliusUi/Grid/Filter/boolean.html.twig",
+        ]);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(GridHelper::class);
+    }
+
+    function it_can_get_filer_ids(): void
+    {
+        $this->getFilterIds()->shouldReturn(['string', 'boolean']);
+    }
+}

--- a/src/Component/spec/Maker/Helper/GridHelperSpec.php
+++ b/src/Component/spec/Maker/Helper/GridHelperSpec.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace spec\Sylius\Component\Grid\Maker\Helper;
 
 use PhpSpec\ObjectBehavior;
@@ -10,8 +21,8 @@ final class GridHelperSpec extends ObjectBehavior
     function let(): void
     {
         $this->beConstructedWith([
-            'string' => "@SyliusUi/Grid/Filter/string.html.twig",
-            'boolean' => "@SyliusUi/Grid/Filter/boolean.html.twig",
+            'string' => '@SyliusUi/Grid/Filter/string.html.twig',
+            'boolean' => '@SyliusUi/Grid/Filter/boolean.html.twig',
         ]);
     }
 

--- a/src/Component/spec/Maker/Helper/ResourceHelperSpec.php
+++ b/src/Component/spec/Maker/Helper/ResourceHelperSpec.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace spec\Sylius\Component\Grid\Maker\Helper;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Grid\Maker\Helper\ResourceHelper;
+
+class ResourceHelperSpec extends ObjectBehavior
+{
+    function let(): void
+    {
+        $this->beConstructedWith([
+            'sylius.shop_user' => [
+                'classes' => [
+                    'model' => 'App\Entity\User\ShopUser',
+                ]
+            ],
+            'sylius.admin_user' => [
+                'classes' => [
+                    'model' => 'App\Entity\User\AdminUser',
+                ]
+            ]
+        ]);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ResourceHelper::class);
+    }
+
+    function it_can_get_resources_aliases(): void
+    {
+        $this->getResourcesAliases()->shouldReturn([
+            'sylius.shop_user',
+            'sylius.admin_user',
+        ]);
+    }
+
+    function it_can_get_resource_model_for_an_alias(): void
+    {
+        $this
+            ->getResourceModelFromAlias('sylius.shop_user')
+            ->shouldReturn('sylius.model.shop_user.class');
+
+        $this
+            ->getResourceModelFromAlias('sylius.admin_user')
+            ->shouldReturn('sylius.model.admin_user.class');
+    }
+
+    function it_can_get_resource_name_for_an_alias(): void
+    {
+        $this
+            ->getResourceNameFromAlias('sylius.shop_user')
+            ->shouldReturn('shop_user');
+
+        $this
+            ->getResourceNameFromAlias('sylius.admin_user')
+            ->shouldReturn('admin_user');
+    }
+
+    function it_can_split_a_resource_alias(): void
+    {
+        $this
+            ->splitResourceAlias('sylius.shop_user')
+            ->shouldReturn(['sylius', 'shop_user']);
+
+        $this
+            ->splitResourceAlias('sylius.admin_user')
+            ->shouldReturn(['sylius', 'admin_user']);
+    }
+}

--- a/src/Component/spec/Maker/Helper/ResourceHelperSpec.php
+++ b/src/Component/spec/Maker/Helper/ResourceHelperSpec.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace spec\Sylius\Component\Grid\Maker\Helper;
 
 use PhpSpec\ObjectBehavior;
@@ -13,13 +24,13 @@ class ResourceHelperSpec extends ObjectBehavior
             'sylius.shop_user' => [
                 'classes' => [
                     'model' => 'App\Entity\User\ShopUser',
-                ]
+                ],
             ],
             'sylius.admin_user' => [
                 'classes' => [
                     'model' => 'App\Entity\User\AdminUser',
-                ]
-            ]
+                ],
+            ],
         ]);
     }
 


### PR DESCRIPTION
### Grid configuration
- [x] driver.name
- [x] driver.options.class
- [ ] driver.options.repository
- [x]  fields.{property}.type
- [x]  fields.{property}.label
- [x]  fields.{property}.sortable
- [x]  fields.{property}.options.template (for twig type)
- [x]  fields.{property}.options.format (for datetime type)
- [x]  sorting.{property}
- [x]  actions.main
- [x]  actions.item
- [x]  actions.bulk
- [x]  filters.type
- [x]  filters.label
- [x]  filters.options.field
- [x]  filters.options.fields
- [x]  filters.form_options
- [ ]  limits

### Import the new grid file configuration
- [ ] Import the new grid file configuration.

### Tests
- [x] Phpspec for services
- [ ] PHPUnit for MakerGridCommand

### Bundle configuration

I think we can add some configuration on the bundle such as the grid configuration path 
We can also add a naming strategy configurable.