### PR TITLE
Add possibility to configure custom service for query builder in doctrine orm driver

### DIFF
--- a/src/Bundle/test/app/config/config.yml
+++ b/src/Bundle/test/app/config/config.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: "@SyliusGridBundle/test/app/config/parameters.yml" }
     - { resource: "@SyliusGridBundle/test/app/config/resources.yml" }
     - { resource: "@SyliusGridBundle/test/app/config/grids.yml" }
+    - { resource: "@SyliusGridBundle/test/app/config/services.yaml" }
 
 framework:
     assets: false

--- a/src/Bundle/test/app/config/grids.yml
+++ b/src/Bundle/test/app/config/grids.yml
@@ -122,7 +122,7 @@ sylius_grid:
                 options:
                     class: AppBundle\Entity\Book
                     repository:
-                        method: createEnglishBooksQueryBuilder
+                        method: [expr:service('app.english_books_query_builder'), create]
             filters:
                 title:
                     type: string

--- a/src/Bundle/test/app/config/services.yaml
+++ b/src/Bundle/test/app/config/services.yaml
@@ -1,0 +1,6 @@
+services:
+    app.english_books_query_builder:
+        class: AppBundle\QueryBuilder\EnglishBooksQueryBuilder
+        arguments:
+            - '@app.repository.book'
+        public: true

--- a/src/Bundle/test/src/AppBundle/QueryBuilder/EnglishBooksQueryBuilder.php
+++ b/src/Bundle/test/src/AppBundle/QueryBuilder/EnglishBooksQueryBuilder.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace AppBundle\QueryBuilder;
+
+use AppBundle\Entity\Author;
+use AppBundle\Repository\BookRepository;
+use Doctrine\ORM\Query\Expr\Join;
+use Doctrine\ORM\QueryBuilder;
+
+final class EnglishBooksQueryBuilder
+{
+    /** @var BookRepository */
+    private $bookRepository;
+
+    public function __construct(BookRepository $bookRepository)
+    {
+        $this->bookRepository = $bookRepository;
+    }
+
+    public function create(): QueryBuilder
+    {
+        return $this->bookRepository->createQueryBuilder('b')
+            ->innerJoin(Author::class, 'author', Join::WITH, 'author.id = b.author')
+            ->innerJoin('author.nationality', 'na')
+            ->andWhere('na.name = :nationality')
+            ->setParameter(':nationality', 'English')
+        ;
+    }
+}

--- a/src/Bundle/test/src/AppBundle/Repository/BookRepository.php
+++ b/src/Bundle/test/src/AppBundle/Repository/BookRepository.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace AppBundle\Repository;
 
-use AppBundle\Entity\Author;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
@@ -26,7 +25,8 @@ final class BookRepository extends EntityRepository
             ->leftJoin('b.attributes', 'size', Join::WITH, 'size.code = :sizeCode')
             ->leftJoin('b.attributes', 'condition', Join::WITH, 'condition.code = :conditionCode')
             ->setParameter(':sizeCode', 'size')
-            ->setParameter(':conditionCode', 'condition');
+            ->setParameter(':conditionCode', 'condition')
+        ;
     }
 
     public function createAmericanBooksQueryBuilder(): QueryBuilder
@@ -37,15 +37,5 @@ final class BookRepository extends EntityRepository
             ->andWhere('na.name = :nationality')
             ->setParameter(':nationality', 'American')
         ;
-    }
-
-    public function createEnglishBooksQueryBuilder(): QueryBuilder
-    {
-        return $this->createQueryBuilder('b')
-            ->innerJoin(Author::class, 'author', Join::WITH, 'author.id = b.author')
-            ->innerJoin('author.nationality', 'na')
-            ->andWhere('na.name = :nationality')
-            ->setParameter(':nationality', 'English')
-            ;
     }
 }


### PR DESCRIPTION
It adds possibility to configure custom query builder in grid:
```
app_book:
    driver:
        name: doctrine/orm
        options:
           class: AppBundle\Entity\Book
           repository:
               method: [expr:service('app.custom_books_query_builder'), create]
```