### PR TITLE
Inject repository through the container instead of doctrine

### DIFF
--- a/src/Bundle/Resources/config/services/integrations/doctrine/orm.xml
+++ b/src/Bundle/Resources/config/services/integrations/doctrine/orm.xml
@@ -16,6 +16,8 @@
         <defaults public="true" />
 
         <service id="sylius.grid_driver.doctrine.orm" class="Sylius\Bundle\GridBundle\Doctrine\ORM\Driver">
+            <argument type="service" id="sylius.resource_registry" />
+            <argument type="service" id="service_container" />
             <argument type="service" id="doctrine" />
             <tag name="sylius.grid_driver" alias="doctrine/orm" />
         </service>


### PR DESCRIPTION
When using this bundle as part of a Sylius project that also uses ResourceBundle, the repository instance that gets used for queries is not the same instance as the one defined by the ResourceBundle. The reason is that the repository here is injected directly by Doctrine, skipping the relevant service definitions set in the container.

This causes problems when you try to inject dependencies into the repository instance, because even though the service configuration in ResouceBundle works fine, when a function like `createListQueryBuilder` is called by GridBundle, the injected dependencies will be null.

This PR attempts to solve this by first looking for a service definition in ResourceBundle and if so using that, otherwise falling back to the original functionality. This solution is not very elegant (we have to inject the whole contianer) and there might a better way of doing, but I would like to at least open the discussion of how this could be done.