### PR TITLE
Update documentation

### DIFF
--- a/docs/custom_filter.md
+++ b/docs/custom_filter.md
@@ -15,7 +15,7 @@ use Sylius\Component\Grid\Filtering\FilterInterface;
 
 class SuppliersStatisticsFilter implements FilterInterface
 {
-    public function apply(DataSourceInterface $dataSource, $name, $data, array $options = [])
+    public function apply(DataSourceInterface $dataSource, $name, $data, array $options = []): void
     {
         // Your filtering logic. DataSource is kind of query builder.
         // $data['stats'] contains the submitted value!
@@ -99,5 +99,5 @@ sylius_grid:
                         range: [0, 100]
     templates:
         filter:
-            suppliers_statistics: 'App:Grid/Filter:suppliers_statistics.html.twig'
+            suppliers_statistics: '/Grid/Filter/suppliers_statistics.html.twig'
 ```


### PR DESCRIPTION
The return type is here according to the interface.
But I'm not sure it's not only 7.4.

And the template path is a normal fix.