### PR TITLE
Added RangeNumerical filter and possibility of using HAVING clause

### DIFF
--- a/src/Bundle/Doctrine/ORM/ExpressionBuilder.php
+++ b/src/Bundle/Doctrine/ORM/ExpressionBuilder.php
@@ -44,114 +44,134 @@ final class ExpressionBuilder implements ExpressionBuilderInterface
         return new Comparison($field, $operator, $value);
     }
 
-    public function equals(string $field, $value)
+    public function equals(string $field, $value, ?bool $addJoinAlias = true)
     {
         $field = $this->adjustField($field);
         $parameterName = $this->getParameterName($field);
         $this->queryBuilder->setParameter($parameterName, $value);
 
-        return $this->queryBuilder->expr()->eq($this->resolveFieldByAddingJoins($field), ':' . $parameterName);
+        $field = true === $addJoinAlias ? $this->resolveFieldByAddingJoins($field) : $field;
+
+        return $this->queryBuilder->expr()->eq($field, ':' . $parameterName);
     }
 
-    public function notEquals(string $field, $value)
+    public function notEquals(string $field, $value, ?bool $addJoinAlias = true)
     {
         $field = $this->adjustField($field);
         $parameterName = $this->getParameterName($field);
         $this->queryBuilder->setParameter($parameterName, $value);
 
-        return $this->queryBuilder->expr()->neq($this->resolveFieldByAddingJoins($field), ':' . $parameterName);
+        $field = true === $addJoinAlias ? $this->resolveFieldByAddingJoins($field) : $field;
+
+        return $this->queryBuilder->expr()->neq($field, ':' . $parameterName);
     }
 
-    public function lessThan(string $field, $value)
+    public function lessThan(string $field, $value, ?bool $addJoinAlias = true)
     {
         $field = $this->adjustField($field);
         $parameterName = $this->getParameterName($field);
         $this->queryBuilder->setParameter($parameterName, $value);
 
-        return $this->queryBuilder->expr()->lt($this->resolveFieldByAddingJoins($field), ':' . $parameterName);
+        $field = true === $addJoinAlias ? $this->resolveFieldByAddingJoins($field) : $field;
+
+        return $this->queryBuilder->expr()->lt($field, ':' . $parameterName);
     }
 
-    public function lessThanOrEqual(string $field, $value)
+    public function lessThanOrEqual(string $field, $value, ?bool $addJoinAlias = true)
     {
         $field = $this->adjustField($field);
         $parameterName = $this->getParameterName($field);
         $this->queryBuilder->setParameter($parameterName, $value);
 
-        return $this->queryBuilder->expr()->lte($this->resolveFieldByAddingJoins($field), ':' . $parameterName);
+        $field = true === $addJoinAlias ? $this->resolveFieldByAddingJoins($field) : $field;
+
+        return $this->queryBuilder->expr()->lte($field, ':' . $parameterName);
     }
 
-    public function greaterThan(string $field, $value)
+    public function greaterThan(string $field, $value, ?bool $addJoinAlias = true)
     {
         $field = $this->adjustField($field);
         $parameterName = $this->getParameterName($field);
         $this->queryBuilder->setParameter($parameterName, $value);
 
-        return $this->queryBuilder->expr()->gt($this->resolveFieldByAddingJoins($field), ':' . $parameterName);
+        $field = true === $addJoinAlias ? $this->resolveFieldByAddingJoins($field) : $field;
+
+        return $this->queryBuilder->expr()->gt($field, ':' . $parameterName);
     }
 
-    public function greaterThanOrEqual(string $field, $value)
+    public function greaterThanOrEqual(string $field, $value, ?bool $addJoinAlias = true)
     {
         $field = $this->adjustField($field);
         $parameterName = $this->getParameterName($field);
         $this->queryBuilder->setParameter($parameterName, $value);
 
-        return $this->queryBuilder->expr()->gte($this->resolveFieldByAddingJoins($field), ':' . $parameterName);
+        $field = true === $addJoinAlias ? $this->resolveFieldByAddingJoins($field) : $field;
+
+        return $this->queryBuilder->expr()->gte($field, ':' . $parameterName);
     }
 
-    public function in(string $field, array $values)
+    public function in(string $field, array $values, ?bool $addJoinAlias = true)
     {
         $field = $this->adjustField($field);
+        $field = true === $addJoinAlias ? $this->resolveFieldByAddingJoins($field) : $field;
 
-        return $this->queryBuilder->expr()->in($this->resolveFieldByAddingJoins($field), $values);
+        return $this->queryBuilder->expr()->in($field, $values);
     }
 
-    public function notIn(string $field, array $values)
+    public function notIn(string $field, array $values, ?bool $addJoinAlias = true)
     {
         $field = $this->adjustField($field);
+        $field = true === $addJoinAlias ? $this->resolveFieldByAddingJoins($field) : $field;
 
-        return $this->queryBuilder->expr()->notIn($this->resolveFieldByAddingJoins($field), $values);
+        return $this->queryBuilder->expr()->notIn($field, $values);
     }
 
-    public function isNull(string $field)
+    public function isNull(string $field, ?bool $addJoinAlias = true)
     {
         $field = $this->adjustField($field);
+        $field = true === $addJoinAlias ? $this->resolveFieldByAddingJoins($field) : $field;
 
-        return $this->queryBuilder->expr()->isNull($this->resolveFieldByAddingJoins($field));
+        return $this->queryBuilder->expr()->isNull($field);
     }
 
-    public function isNotNull(string $field)
+    public function isNotNull(string $field, ?bool $addJoinAlias = true)
     {
         $field = $this->adjustField($field);
+        $field = true === $addJoinAlias ? $this->resolveFieldByAddingJoins($field) : $field;
 
-        return $this->queryBuilder->expr()->isNotNull($this->resolveFieldByAddingJoins($field));
+        return $this->queryBuilder->expr()->isNotNull($field);
     }
 
-    public function like(string $field, string $pattern)
+    public function like(string $field, string $pattern, ?bool $addJoinAlias = true)
     {
         $field = $this->adjustField($field);
+        $field = true === $addJoinAlias ? $this->resolveFieldByAddingJoins($field) : $field;
 
-        return $this->queryBuilder->expr()->like($this->resolveFieldByAddingJoins($field), $this->queryBuilder->expr()->literal($pattern));
+        return $this->queryBuilder->expr()->like($field, $this->queryBuilder->expr()->literal($pattern));
     }
 
-    public function notLike(string $field, string $pattern)
+    public function notLike(string $field, string $pattern, ?bool $addJoinAlias = true)
     {
         $field = $this->adjustField($field);
+        $field = true === $addJoinAlias ? $this->resolveFieldByAddingJoins($field) : $field;
 
-        return $this->queryBuilder->expr()->notLike($this->resolveFieldByAddingJoins($field), $this->queryBuilder->expr()->literal($pattern));
+        return $this->queryBuilder->expr()->notLike($field, $this->queryBuilder->expr()->literal($pattern));
     }
 
-    public function orderBy(string $field, string $direction)
+    public function orderBy(string $field, string $direction, ?bool $addJoinAlias = true)
     {
         $field = $this->adjustField($field);
+        $field = true === $addJoinAlias ? $this->resolveFieldByAddingJoins($field) : $field;
 
-        return $this->queryBuilder->orderBy($this->resolveFieldByAddingJoins($field), $direction);
+        return $this->queryBuilder->orderBy($field, $direction);
     }
 
-    public function addOrderBy(string $field, string $direction)
+    public function addOrderBy(string $field, string $direction, ?bool $addJoinAlias = true)
     {
         $field = $this->adjustField($field);
+        $field = true === $addJoinAlias ? $this->resolveFieldByAddingJoins($field) : $field;
 
-        return $this->queryBuilder->addOrderBy($this->resolveFieldByAddingJoins($field), $direction);
+        return $this->queryBuilder->addOrderBy($field, $direction);
     }
 
     private function getParameterName(string $field): string

--- a/src/Bundle/Form/Type/Filter/RangeNumericalFilterType.php
+++ b/src/Bundle/Form/Type/Filter/RangeNumericalFilterType.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\GridBundle\Form\Type\Filter;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class RangeNumericalFilterType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('from', IntegerType::class, [
+                'label' => 'sylius.ui.from',
+                'required' => false,
+            ])
+            ->add('to', IntegerType::class, [
+                'label' => 'sylius.ui.to',
+                'required' => false,
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver
+            ->setDefaults([
+                'data_class' => null,
+            ])
+        ;
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_grid_filter_range_numerical';
+    }
+}

--- a/src/Component/Data/DataSourceInterface.php
+++ b/src/Component/Data/DataSourceInterface.php
@@ -21,6 +21,10 @@ interface DataSourceInterface
 
     public const CONDITION_OR = 'or';
 
+    public const CONDITION_HAVING_AND = 'having and';
+
+    public const CONDITION_HAVING_OR = 'having or';
+
     /**
      * @param mixed $expression
      */

--- a/src/Component/Data/ExpressionBuilderInterface.php
+++ b/src/Component/Data/ExpressionBuilderInterface.php
@@ -41,80 +41,80 @@ interface ExpressionBuilderInterface
      *
      * @return mixed
      */
-    public function equals(string $field, $value);
+    public function equals(string $field, $value, ?bool$addJoinAlias = true);
 
     /**
      * @param mixed $value
      *
      * @return mixed
      */
-    public function notEquals(string $field, $value);
+    public function notEquals(string $field, $value, ?bool$addJoinAlias = true);
 
     /**
      * @param mixed $value
      *
      * @return mixed
      */
-    public function lessThan(string $field, $value);
+    public function lessThan(string $field, $value, ?bool$addJoinAlias = true);
 
     /**
      * @param mixed $value
      *
      * @return mixed
      */
-    public function lessThanOrEqual(string $field, $value);
+    public function lessThanOrEqual(string $field, $value, ?bool$addJoinAlias = true);
 
     /**
      * @param mixed $value
      *
      * @return mixed
      */
-    public function greaterThan(string $field, $value);
+    public function greaterThan(string $field, $value, ?bool$addJoinAlias = true);
 
     /**
      * @param mixed $value
      *
      * @return mixed
      */
-    public function greaterThanOrEqual(string $field, $value);
+    public function greaterThanOrEqual(string $field, $value, ?bool$addJoinAlias = true);
 
     /**
      * @return mixed
      */
-    public function in(string $field, array $values);
+    public function in(string $field, array $values, ?bool$addJoinAlias = true);
 
     /**
      * @return mixed
      */
-    public function notIn(string $field, array $values);
+    public function notIn(string $field, array $values, ?bool$addJoinAlias = true);
 
     /**
      * @return mixed
      */
-    public function isNull(string $field);
+    public function isNull(string $field, ?bool$addJoinAlias = true);
 
     /**
      * @return mixed
      */
-    public function isNotNull(string $field);
+    public function isNotNull(string $field, ?bool$addJoinAlias = true);
 
     /**
      * @return mixed
      */
-    public function like(string $field, string $pattern);
+    public function like(string $field, string $pattern, ?bool$addJoinAlias = true);
 
     /**
      * @return mixed
      */
-    public function notLike(string $field, string $pattern);
+    public function notLike(string $field, string $pattern, ?bool$addJoinAlias = true);
 
     /**
      * @return mixed
      */
-    public function orderBy(string $field, string $direction);
+    public function orderBy(string $field, string $direction, ?bool$addJoinAlias = true);
 
     /**
      * @return mixed
      */
-    public function addOrderBy(string $field, string $direction);
+    public function addOrderBy(string $field, string $direction, ?bool$addJoinAlias = true);
 }

--- a/src/Component/Filter/RangeNumericalFilter.php
+++ b/src/Component/Filter/RangeNumericalFilter.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Filter;
+
+use Sylius\Component\Grid\Data\DataSourceInterface;
+use Sylius\Component\Grid\Filtering\FilterInterface;
+
+final class RangeNumericalFilter implements FilterInterface
+{
+    public const DEFAULT_INCLUSIVE_FROM = true;
+
+    public const DEFAULT_INCLUSIVE_TO = true;
+
+    public function apply(DataSourceInterface $dataSource, string $name, $data, array $options): void
+    {
+        $expressionBuilder = $dataSource->getExpressionBuilder();
+
+        $field = (string) $this->getOption($options, 'field', $name);
+        $from = $data['from'] ?? null;
+
+        if (false === empty($from)) {
+            $dataSource->restrict(
+                $expressionBuilder->greaterThanOrEqual($field, $from),
+                DataSourceInterface::CONDITION_HAVING_AND
+            );
+        }
+
+        $to = $data['to'] ?? null;
+
+        if (false === empty($to)) {
+            $dataSource->restrict(
+                $expressionBuilder->lessThanOrEqual($field, $to),
+                DataSourceInterface::CONDITION_HAVING_AND
+            );
+        }
+    }
+
+    private function getOption(array $options, string $name, $default)
+    {
+        return $options[$name] ?? $default;
+    }
+}

--- a/src/Component/spec/Filter/RangeNumericalFilterSpec.php
+++ b/src/Component/spec/Filter/RangeNumericalFilterSpec.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Grid\Filter;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Grid\Data\DataSourceInterface;
+use Sylius\Component\Grid\Data\ExpressionBuilderInterface;
+use Sylius\Component\Grid\Filtering\FilterInterface;
+
+final class RangeNumericalFilterSpec extends ObjectBehavior
+{
+    function it_implements_a_filter_interface(): void
+    {
+        $this->shouldImplement(FilterInterface::class);
+    }
+
+    function it_filters_number_from(
+        DataSourceInterface $dataSource,
+        ExpressionBuilderInterface $expressionBuilder
+    ): void {
+        $dataSource->getExpressionBuilder()->willReturn($expressionBuilder);
+
+        $expressionBuilder->greaterThanOrEqual('number', '3')->willReturn('EXPR');
+        $dataSource->restrict('EXPR', DataSourceInterface::CONDITION_HAVING_AND)->shouldBeCalled();
+
+        $this->apply(
+            $dataSource,
+            'number',
+            [
+                'from' => '3',
+            ],
+            []
+        );
+    }
+
+    function it_filters_number_to(
+        DataSourceInterface $dataSource,
+        ExpressionBuilderInterface $expressionBuilder
+    ): void {
+        $dataSource->getExpressionBuilder()->willReturn($expressionBuilder);
+
+        $expressionBuilder->lessThanOrEqual('number', '8')->willReturn('EXPR');
+        $dataSource->restrict('EXPR', DataSourceInterface::CONDITION_HAVING_AND)->shouldBeCalled();
+
+        $this->apply(
+            $dataSource,
+            'number',
+            [
+                'to' => '8',
+            ],
+            []
+        );
+    }
+
+    function it_filters_number_from_to(
+        DataSourceInterface $dataSource,
+        ExpressionBuilderInterface $expressionBuilder
+    ): void {
+        $dataSource->getExpressionBuilder()->willReturn($expressionBuilder);
+
+        $expressionBuilder->greaterThanOrEqual('number', '2')->willReturn('EXPR1');
+        $dataSource->restrict('EXPR1', DataSourceInterface::CONDITION_HAVING_AND)->shouldBeCalled();
+
+        $expressionBuilder->lessThanOrEqual('number', '4')->willReturn('EXPR2');
+        $dataSource->restrict('EXPR2', DataSourceInterface::CONDITION_HAVING_AND)->shouldBeCalled();
+
+        $this->apply(
+            $dataSource,
+            'number',
+            [
+                'from' => '2',
+                'to' => '4',
+            ],
+            []
+        );
+    }
+}


### PR DESCRIPTION
```
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #
| License         | MIT
```

While working on adding a custom filter, I thought that it could be in the bundle.
I add `range numerical` filter which can filter on numerical fields in range (from-to) Like existing DateFilter.

Also in this pull request is a small change in two classes:
- `Doctrine\ORM \ExpressionBuilder`
- `Doctrine\ORM\DataSource`.

I suggested adding filtering capability also when using HAVING instead of WHERE in the query. For example, when we use `count (*)`. Please give your opinion what do you think about it?

This idea also came while working on this filter because I had to filter in queries with the `HAVING` clause.