### PR TITLE
Fixed template syntax in route config

### DIFF
--- a/docs/your_first_grid.md
+++ b/docs/your_first_grid.md
@@ -71,7 +71,7 @@ app_admin_supplier:
     resource: |
         alias: app.supplier
         section: admin
-        templates: SyliusAdminBundle:Crud
+        templates: "@SyliusAdmin\\Crud"
         except: ['show']
         redirect: update
         grid: app_admin_supplier


### PR DESCRIPTION
Spotted old template syntax in one of the docs which no longer works