### PR TITLE
[GridBuilder] Allow using class as parameter for grids as service

### DIFF
--- a/src/Bundle/Grid/AbstractGrid.php
+++ b/src/Bundle/Grid/AbstractGrid.php
@@ -30,7 +30,7 @@ abstract class AbstractGrid implements GridInterface
     private function createGridBuilder(): GridBuilderInterface
     {
         if ($this instanceof ResourceAwareGridInterface) {
-            return GridBuilder::create($this::getName(), $this::getResourceClass());
+            return GridBuilder::create($this::getName(), $this->getResourceClass());
         }
 
         return GridBuilder::create($this::getName());

--- a/src/Bundle/Grid/ResourceAwareGridInterface.php
+++ b/src/Bundle/Grid/ResourceAwareGridInterface.php
@@ -15,5 +15,5 @@ namespace Sylius\Bundle\GridBundle\Grid;
 
 interface ResourceAwareGridInterface extends GridInterface
 {
-    public static function getResourceClass(): string;
+    public function getResourceClass(): string;
 }

--- a/src/Bundle/Tests/DependencyInjection/GridBuilderConfigurationTest.php
+++ b/src/Bundle/Tests/DependencyInjection/GridBuilderConfigurationTest.php
@@ -40,9 +40,11 @@ use Sylius\Bundle\GridBundle\Builder\GridBuilder;
 use Sylius\Bundle\GridBundle\DependencyInjection\Configuration;
 use Sylius\Bundle\GridBundle\DependencyInjection\SyliusGridExtension;
 use Sylius\Bundle\GridBundle\Doctrine\ORM\Driver;
+use Sylius\Component\Grid\Tests\Dummy\ClassAsParameterGrid;
 use Sylius\Component\Grid\Tests\Dummy\Foo;
 use Sylius\Component\Grid\Tests\Dummy\FooGrid;
 use Sylius\Component\Grid\Tests\Dummy\NoResourceGrid;
+use Symfony\Component\DependencyInjection\Definition;
 
 final class GridBuilderConfigurationTest extends AbstractExtensionTestCase
 {
@@ -674,6 +676,36 @@ final class GridBuilderConfigurationTest extends AbstractExtensionTestCase
                     'name' => Driver::NAME,
                     'options' => [
                         'class' => Foo::class,
+                    ],
+                ],
+                'sorting' => [],
+                'limits' => [10, 25, 50],
+                'fields' => [],
+                'filters' => [],
+                'actions' => [],
+            ],
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_builds_grid_with_resource_class_as_parameter_and_grid_as_service(): void
+    {
+        $grid = new ClassAsParameterGrid(Author::class);
+
+        $this->load([
+            'grids' => [
+                'app_class_as_parameter' => $grid->toArray(),
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasParameter('sylius.grids_definitions', [
+            'app_class_as_parameter' => [
+                'driver' => [
+                    'name' => Driver::NAME,
+                    'options' => [
+                        'class' => Author::class,
                     ],
                 ],
                 'sorting' => [],

--- a/src/Bundle/test/config/services.yaml
+++ b/src/Bundle/test/config/services.yaml
@@ -9,6 +9,9 @@ parameters:
     secret: "Three can keep a secret, if two of them are dead."
 
 services:
+    bind:
+        $authorClass: '%app.model.author.class%'
+
     app.english_books_query_builder:
         class: App\QueryBuilder\EnglishBooksQueryBuilder
         arguments:

--- a/src/Bundle/test/config/services.yaml
+++ b/src/Bundle/test/config/services.yaml
@@ -9,9 +9,6 @@ parameters:
     secret: "Three can keep a secret, if two of them are dead."
 
 services:
-    bind:
-        $authorClass: '%app.model.author.class%'
-
     app.english_books_query_builder:
         class: App\QueryBuilder\EnglishBooksQueryBuilder
         arguments:

--- a/src/Bundle/test/config/services_test_grids_as_service.yaml
+++ b/src/Bundle/test/config/services_test_grids_as_service.yaml
@@ -2,6 +2,8 @@ services:
     _defaults:
         autowire: true
         autoconfigure: true
+        bind:
+            $authorClass: '%app.model.author.class%'
 
     App\QueryBuilder\EnglishBooksQueryBuilder: null
 

--- a/src/Bundle/test/src/Grid/AuthorGrid.php
+++ b/src/Bundle/test/src/Grid/AuthorGrid.php
@@ -22,14 +22,21 @@ use Sylius\Bundle\GridBundle\Grid\ResourceAwareGridInterface;
 
 final class AuthorGrid extends AbstractGrid implements ResourceAwareGridInterface
 {
+    private string $authorClass;
+
+    public function __construct(string $authorClass)
+    {
+        $this->authorClass = $authorClass;
+    }
+
     public static function getName(): string
     {
         return 'app_author';
     }
 
-    public static function getResourceClass(): string
+    public function getResourceClass(): string
     {
-        return Author::class;
+        return $this->authorClass;
     }
 
     public function buildGrid(GridBuilderInterface $gridBuilder): void

--- a/src/Bundle/test/src/Grid/AuthorWithBooksWithFetchJoinCollectionDisabled.php
+++ b/src/Bundle/test/src/Grid/AuthorWithBooksWithFetchJoinCollectionDisabled.php
@@ -25,7 +25,7 @@ final class AuthorWithBooksWithFetchJoinCollectionDisabled extends AbstractGrid 
         return 'app_author_with_books_with_fetch_join_collection_disabled';
     }
 
-    public static function getResourceClass(): string
+    public function getResourceClass(): string
     {
         return Author::class;
     }

--- a/src/Bundle/test/src/Grid/AuthorWithBooksWithFetchJoinCollectionEnabled.php
+++ b/src/Bundle/test/src/Grid/AuthorWithBooksWithFetchJoinCollectionEnabled.php
@@ -25,7 +25,7 @@ final class AuthorWithBooksWithFetchJoinCollectionEnabled extends AbstractGrid i
         return 'app_author_with_books_with_fetch_join_collection_enabled';
     }
 
-    public static function getResourceClass(): string
+    public function getResourceClass(): string
     {
         return Author::class;
     }

--- a/src/Bundle/test/src/Grid/AuthorWithBooksWithUseOutputWalkersDisabled.php
+++ b/src/Bundle/test/src/Grid/AuthorWithBooksWithUseOutputWalkersDisabled.php
@@ -26,7 +26,7 @@ final class AuthorWithBooksWithUseOutputWalkersDisabled extends AbstractGrid imp
         return 'app_author_with_books_with_use_output_walkers_disabled';
     }
 
-    public static function getResourceClass(): string
+    public function getResourceClass(): string
     {
         return Author::class;
     }

--- a/src/Bundle/test/src/Grid/AuthorWithBooksWithUseOutputWalkersEnabled.php
+++ b/src/Bundle/test/src/Grid/AuthorWithBooksWithUseOutputWalkersEnabled.php
@@ -26,7 +26,7 @@ final class AuthorWithBooksWithUseOutputWalkersEnabled extends AbstractGrid impl
         return 'app_author_with_books_with_use_output_walkers_enabled';
     }
 
-    public static function getResourceClass(): string
+    public function getResourceClass(): string
     {
         return Author::class;
     }

--- a/src/Bundle/test/src/Grid/BookByAmericanAuthorsGrid.php
+++ b/src/Bundle/test/src/Grid/BookByAmericanAuthorsGrid.php
@@ -28,7 +28,7 @@ final class BookByAmericanAuthorsGrid extends AbstractGrid implements ResourceAw
         return 'app_book_by_american_authors';
     }
 
-    public static function getResourceClass(): string
+    public function getResourceClass(): string
     {
         return Book::class;
     }

--- a/src/Bundle/test/src/Grid/BookByEnglishAuthorsGrid.php
+++ b/src/Bundle/test/src/Grid/BookByEnglishAuthorsGrid.php
@@ -36,7 +36,7 @@ final class BookByEnglishAuthorsGrid extends AbstractGrid implements ResourceAwa
         return 'app_book_by_english_authors';
     }
 
-    public static function getResourceClass(): string
+    public function getResourceClass(): string
     {
         return Book::class;
     }

--- a/src/Bundle/test/src/Grid/BookGrid.php
+++ b/src/Bundle/test/src/Grid/BookGrid.php
@@ -29,7 +29,7 @@ final class BookGrid extends AbstractGrid implements ResourceAwareGridInterface
         return 'app_book';
     }
 
-    public static function getResourceClass(): string
+    public function getResourceClass(): string
     {
         return Book::class;
     }

--- a/src/Component/Tests/Dummy/BarGrid.php
+++ b/src/Component/Tests/Dummy/BarGrid.php
@@ -24,7 +24,7 @@ final class BarGrid extends AbstractGrid implements ResourceAwareGridInterface
         return 'app_bar';
     }
 
-    public static function getResourceClass(): string
+    public function getResourceClass(): string
     {
         return Bar::class;
     }

--- a/src/Component/Tests/Dummy/ClassAsParameterGrid.php
+++ b/src/Component/Tests/Dummy/ClassAsParameterGrid.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Sylius package.
- *
- * (c) Paweł Jędrzejewski
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 declare(strict_types=1);
 
 namespace Sylius\Component\Grid\Tests\Dummy;
@@ -17,16 +8,23 @@ use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\AbstractGrid;
 use Sylius\Bundle\GridBundle\Grid\ResourceAwareGridInterface;
 
-final class FooGrid extends AbstractGrid implements ResourceAwareGridInterface
+final class ClassAsParameterGrid extends AbstractGrid implements ResourceAwareGridInterface
 {
+    private string $authorClass;
+
+    public function __construct(string $authorClass)
+    {
+        $this->authorClass = $authorClass;
+    }
+
     public static function getName(): string
     {
-        return 'app_foo';
+        return 'app_class_as_parameter';
     }
 
     public function getResourceClass(): string
     {
-        return Foo::class;
+        return $this->authorClass;
     }
 
     public function buildGrid(GridBuilderInterface $gridBuilder): void


### PR DESCRIPTION
With a resource class as parameter, it already works like this code below

```yaml
services:
    _defaults:
        bind:
            $productClass: '%sylius.model.product.class%'
```

and using driver option

```php
<?php

declare(strict_types=1);

namespace App\Grid;

use App\Entity\Product\Product;
use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
use Sylius\Bundle\GridBundle\Grid\AbstractGrid;

final class AdminProductGrid extends AbstractGrid
{
    private string $productClass;

    public function __construct(string $productClass)
    {
        $this->productClass = $productClass;
    }

    public static function getName(): string
    {
        return 'sylius_admin_product';
    }

    public function buildGrid(GridBuilderInterface $gridBuilder): void
    {
        $gridBuilder
            ->setDriverOption('class', $this->productClass)
        ;
    }
}
```

But I think it's better like this

```php
<?php

declare(strict_types=1);

namespace App\Grid;

use App\Entity\Product\Product;
use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
use Sylius\Bundle\GridBundle\Grid\AbstractGrid;

final class AdminProductGrid extends AbstractGrid
{
    private string $productClass;

    public function __construct(string $productClass)
    {
        $this->productClass = $productClass;
    }

    public static function getName(): string
    {
        return 'sylius_admin_product';
    }

    public function getResourceClass(): string
    {
        return $this->productClass;
    }

    public function buildGrid(GridBuilderInterface $gridBuilder): void
    {
    }
}
```

But it requires to remove the "static" for the getResourceClass method.