### PR TITLE
Add a conflict for pagerfanta 3.0 before allowing it in #143

### DIFF
--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -1,0 +1,19 @@
+# CONFLICTS
+
+This document explains why certain conflicts were added to `composer.json` and
+references related issues.
+
+## Pagerfanta 3 
+
+Pagerfanta 3 is not supported yet due to the usage of deprecated `Pagerfanta\Adapter\DoctrineORMAdapter`. 
+ 
+* `Sylius\Bundle\GridBundle\Doctrine\ORM\DataSource` 
+* `Sylius\Bundle\GridBundle\Doctrine\DBAL\DataSource`
+
+So we added these 4 conflicts. 
+These conflicts will be removed in the next release.
+
+* "pagerfanta/doctrine-dbal-adapter": ">=3.0"
+* "pagerfanta/doctrine-orm-adapter": ">=3.0"
+* "pagerfanta/doctrine-phpcr-odm-adapter": ">=3.0"
+* "pagerfanta/pagerfanta": ">=3.0"

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,10 @@
         "sylius/grid": "self.version"
     },
     "conflict": {
-        "pagerfanta/pagerfanta": "^3.0",
+        "pagerfanta/doctrine-dbal-adapter": ">=3.0",
+        "pagerfanta/doctrine-orm-adapter": ">=3.0",
+        "pagerfanta/doctrine-phpcr-odm-adapter": ">=3.0",
+        "pagerfanta/pagerfanta": ">=3.0",
         "twig/twig": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
         "sylius/grid": "self.version"
     },
     "conflict": {
+        "pagerfanta/pagerfanta": "^3.0",
         "twig/twig": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
On Sylius\Bundle\GridBundle\Docctrine\DBAL\DataSource, there is a usage of Pagerfanta\Adapter\DoctrineDbalAdapter which does not exist on pagerfanta 3.0.

It will be replaced on #143 
https://github.com/Sylius/SyliusGridBundle/blob/5da00cdd4916473025de064822332ed5144c959f/src/Bundle/Doctrine/DBAL/DataSource.php#L17