### PR TITLE
Hotfix with datasources

### DIFF
--- a/src/Bundle/Doctrine/DBAL/DataSource.php
+++ b/src/Bundle/Doctrine/DBAL/DataSource.php
@@ -53,6 +53,8 @@ final class DataSource implements DataSourceInterface
 
     public function getData(Parameters $parameters)
     {
+        $page = (int) $parameters->get('page', 1);
+
         $countQueryBuilderModifier = function (QueryBuilder $queryBuilder): void {
             $queryBuilder
                 ->select('COUNT(DISTINCT o.id) AS total_results')
@@ -62,7 +64,7 @@ final class DataSource implements DataSourceInterface
 
         $paginator = new Pagerfanta(new QueryAdapter($this->queryBuilder, $countQueryBuilderModifier));
         $paginator->setNormalizeOutOfRangePages(true);
-        $paginator->setCurrentPage((int) $parameters->get('page', 1));
+        $paginator->setCurrentPage($page > 0 ? $page : 1);
 
         return $paginator;
     }

--- a/src/Bundle/Doctrine/DBAL/DataSource.php
+++ b/src/Bundle/Doctrine/DBAL/DataSource.php
@@ -62,7 +62,7 @@ final class DataSource implements DataSourceInterface
 
         $paginator = new Pagerfanta(new QueryAdapter($this->queryBuilder, $countQueryBuilderModifier));
         $paginator->setNormalizeOutOfRangePages(true);
-        $paginator->setCurrentPage($parameters->get('page', 1));
+        $paginator->setCurrentPage((int) $parameters->get('page', 1));
 
         return $paginator;
     }

--- a/src/Bundle/Doctrine/ORM/DataSource.php
+++ b/src/Bundle/Doctrine/ORM/DataSource.php
@@ -67,11 +67,13 @@ final class DataSource implements DataSourceInterface
 
     public function getData(Parameters $parameters)
     {
+        $page = (int) $parameters->get('page', 1);
+
         $paginator = new Pagerfanta(
             new QueryAdapter($this->queryBuilder, $this->fetchJoinCollection, $this->useOutputWalkers)
         );
         $paginator->setNormalizeOutOfRangePages(true);
-        $paginator->setCurrentPage((int) $parameters->get('page', 1));
+        $paginator->setCurrentPage($page > 0 ? $page : 1);
 
         return $paginator;
     }

--- a/src/Bundle/Doctrine/ORM/DataSource.php
+++ b/src/Bundle/Doctrine/ORM/DataSource.php
@@ -71,7 +71,7 @@ final class DataSource implements DataSourceInterface
             new QueryAdapter($this->queryBuilder, $this->fetchJoinCollection, $this->useOutputWalkers)
         );
         $paginator->setNormalizeOutOfRangePages(true);
-        $paginator->setCurrentPage($parameters->get('page', 1));
+        $paginator->setCurrentPage((int) $parameters->get('page', 1));
 
         return $paginator;
     }

--- a/src/Bundle/Doctrine/PHPCRODM/DataSource.php
+++ b/src/Bundle/Doctrine/PHPCRODM/DataSource.php
@@ -76,7 +76,7 @@ final class DataSource implements DataSourceInterface
         }
 
         $paginator = new Pagerfanta(new QueryAdapter($this->queryBuilder));
-        $paginator->setCurrentPage($parameters->get('page', 1));
+        $paginator->setCurrentPage((int) $parameters->get('page', 1));
 
         return $paginator;
     }

--- a/src/Bundle/spec/Doctrine/DBAL/DataSourceSpec.php
+++ b/src/Bundle/spec/Doctrine/DBAL/DataSourceSpec.php
@@ -22,17 +22,19 @@ use Sylius\Component\Grid\Parameters;
 
 final class DataSourceSpec extends ObjectBehavior
 {
-    function it_implements_data_source(QueryBuilder $queryBuilder): void
+    function let(QueryBuilder $queryBuilder): void
     {
         $this->beConstructedWith($queryBuilder);
+    }
 
+    function it_implements_data_source(): void
+    {
         $this->shouldImplement(DataSourceInterface::class);
     }
 
     function it_gets_the_data(QueryBuilder $queryBuilder): void
     {
         $queryBuilder->getType()->willReturn(QueryBuilder::SELECT);
-        $this->beConstructedWith($queryBuilder);
 
         $this->getData(new Parameters(['page' => '1']))->shouldHaveType(Pagerfanta::class);
     }

--- a/src/Bundle/spec/Doctrine/DBAL/DataSourceSpec.php
+++ b/src/Bundle/spec/Doctrine/DBAL/DataSourceSpec.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\GridBundle\Doctrine\DBAL;
+
+use Doctrine\DBAL\Query;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Pagerfanta\Pagerfanta;
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Grid\Data\DataSourceInterface;
+use Sylius\Component\Grid\Parameters;
+
+final class DataSourceSpec extends ObjectBehavior
+{
+    function it_implements_data_source(
+        QueryBuilder $queryBuilder
+    ): void
+    {
+        $this->beConstructedWith($queryBuilder);
+
+        $this->shouldImplement(DataSourceInterface::class);
+    }
+
+    function it_should_get_the_data(QueryBuilder $queryBuilder): void
+    {
+        $queryBuilder->getType()->willReturn(QueryBuilder::SELECT);
+        $this->beConstructedWith($queryBuilder);
+
+        $this->getData(new Parameters(['page' => '1']))->shouldHaveType(Pagerfanta::class);
+    }
+}

--- a/src/Bundle/spec/Doctrine/DBAL/DataSourceSpec.php
+++ b/src/Bundle/spec/Doctrine/DBAL/DataSourceSpec.php
@@ -22,16 +22,14 @@ use Sylius\Component\Grid\Parameters;
 
 final class DataSourceSpec extends ObjectBehavior
 {
-    function it_implements_data_source(
-        QueryBuilder $queryBuilder
-    ): void
+    function it_implements_data_source(QueryBuilder $queryBuilder): void
     {
         $this->beConstructedWith($queryBuilder);
 
         $this->shouldImplement(DataSourceInterface::class);
     }
 
-    function it_should_get_the_data(QueryBuilder $queryBuilder): void
+    function it_gets_the_data(QueryBuilder $queryBuilder): void
     {
         $queryBuilder->getType()->willReturn(QueryBuilder::SELECT);
         $this->beConstructedWith($queryBuilder);

--- a/src/Bundle/spec/Doctrine/DBAL/DataSourceSpec.php
+++ b/src/Bundle/spec/Doctrine/DBAL/DataSourceSpec.php
@@ -36,6 +36,10 @@ final class DataSourceSpec extends ObjectBehavior
     {
         $queryBuilder->getType()->willReturn(QueryBuilder::SELECT);
 
-        $this->getData(new Parameters(['page' => '1']))->shouldHaveType(Pagerfanta::class);
+        $data = $this->getData(new Parameters(['page' => '1']));
+
+        $data->shouldHaveType(Pagerfanta::class);
+        $data->getCurrentPage()->shouldReturn(1);
+        $data->getNormalizeOutOfRangePages()->shouldReturn(true);
     }
 }

--- a/src/Bundle/spec/Doctrine/ORM/DataSourceSpec.php
+++ b/src/Bundle/spec/Doctrine/ORM/DataSourceSpec.php
@@ -21,17 +21,18 @@ use Sylius\Component\Grid\Parameters;
 
 final class DataSourceSpec extends ObjectBehavior
 {
-    function it_implements_data_source(QueryBuilder $queryBuilder): void
+    function let(QueryBuilder $queryBuilder): void
     {
         $this->beConstructedWith($queryBuilder, false, false);
+    }
 
+    function it_implements_data_source(): void
+    {
         $this->shouldImplement(DataSourceInterface::class);
     }
 
-    function it_gets_the_data(QueryBuilder $queryBuilder): void
+    function it_gets_the_data(): void
     {
-        $this->beConstructedWith($queryBuilder, false, false);
-
         $this->getData(new Parameters(['page' => '1']))->shouldHaveType(Pagerfanta::class);
     }
 }

--- a/src/Bundle/spec/Doctrine/ORM/DataSourceSpec.php
+++ b/src/Bundle/spec/Doctrine/ORM/DataSourceSpec.php
@@ -21,16 +21,14 @@ use Sylius\Component\Grid\Parameters;
 
 final class DataSourceSpec extends ObjectBehavior
 {
-    function it_implements_data_source(
-        QueryBuilder $queryBuilder
-    ): void
+    function it_implements_data_source(QueryBuilder $queryBuilder): void
     {
         $this->beConstructedWith($queryBuilder, false, false);
 
         $this->shouldImplement(DataSourceInterface::class);
     }
 
-    function it_should_get_the_data(QueryBuilder $queryBuilder): void
+    function it_gets_the_data(QueryBuilder $queryBuilder): void
     {
         $this->beConstructedWith($queryBuilder, false, false);
 

--- a/src/Bundle/spec/Doctrine/ORM/DataSourceSpec.php
+++ b/src/Bundle/spec/Doctrine/ORM/DataSourceSpec.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\GridBundle\Doctrine\ORM;
+
+use Doctrine\ORM\QueryBuilder;
+use Pagerfanta\Pagerfanta;
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Grid\Data\DataSourceInterface;
+use Sylius\Component\Grid\Parameters;
+
+final class DataSourceSpec extends ObjectBehavior
+{
+    function it_implements_data_source(
+        QueryBuilder $queryBuilder
+    ): void
+    {
+        $this->beConstructedWith($queryBuilder, false, false);
+
+        $this->shouldImplement(DataSourceInterface::class);
+    }
+
+    function it_should_get_the_data(QueryBuilder $queryBuilder): void
+    {
+        $this->beConstructedWith($queryBuilder, false, false);
+
+        $this->getData(new Parameters(['page' => '1']))->shouldHaveType(Pagerfanta::class);
+    }
+}

--- a/src/Bundle/spec/Doctrine/ORM/DataSourceSpec.php
+++ b/src/Bundle/spec/Doctrine/ORM/DataSourceSpec.php
@@ -33,6 +33,10 @@ final class DataSourceSpec extends ObjectBehavior
 
     function it_gets_the_data(): void
     {
-        $this->getData(new Parameters(['page' => '1']))->shouldHaveType(Pagerfanta::class);
+        $data = $this->getData(new Parameters(['page' => '1']));
+
+        $data->shouldHaveType(Pagerfanta::class);
+        $data->getCurrentPage()->shouldReturn(1);
+        $data->getNormalizeOutOfRangePages()->shouldReturn(true);
     }
 }

--- a/src/Bundle/spec/Doctrine/PHPCRODM/DataSourceSpec.php
+++ b/src/Bundle/spec/Doctrine/PHPCRODM/DataSourceSpec.php
@@ -103,7 +103,7 @@ final class DataSourceSpec extends ObjectBehavior
         $query->setFirstResult(Argument::any())->willReturn($query);
         $query->execute()->willReturn([]);
 
-        $this->getData(new Parameters(['page' => 1]))->shouldHaveType(Pagerfanta::class);
+        $this->getData(new Parameters(['page' => '1']))->shouldHaveType(Pagerfanta::class);
     }
 
     function it_should_set_the_order_on_the_query_builder(
@@ -130,7 +130,7 @@ final class DataSourceSpec extends ObjectBehavior
         $query->setFirstResult(Argument::any())->willReturn($query);
         $query->execute()->willReturn([]);
 
-        $this->getData(new Parameters(['page' => 1]))->shouldHaveType(Pagerfanta::class);
+        $this->getData(new Parameters(['page' => '1']))->shouldHaveType(Pagerfanta::class);
     }
 
     function it_should_set_the_order_on_the_query_builder_as_fields_only(
@@ -157,6 +157,6 @@ final class DataSourceSpec extends ObjectBehavior
         $query->setFirstResult(Argument::any())->willReturn($query);
         $query->execute()->willReturn([]);
 
-        $this->getData(new Parameters(['page' => 1]))->shouldHaveType(Pagerfanta::class);
+        $this->getData(new Parameters(['page' => '1']))->shouldHaveType(Pagerfanta::class);
     }
 }

--- a/src/Bundle/spec/Doctrine/PHPCRODM/DataSourceSpec.php
+++ b/src/Bundle/spec/Doctrine/PHPCRODM/DataSourceSpec.php
@@ -103,7 +103,11 @@ final class DataSourceSpec extends ObjectBehavior
         $query->setFirstResult(Argument::any())->willReturn($query);
         $query->execute()->willReturn([]);
 
-        $this->getData(new Parameters(['page' => '1']))->shouldHaveType(Pagerfanta::class);
+        $data = $this->getData(new Parameters(['page' => '1']));
+
+        $data->shouldHaveType(Pagerfanta::class);
+        $data->getCurrentPage()->shouldReturn(1);
+        $data->getNormalizeOutOfRangePages()->shouldReturn(false);
     }
 
     function it_should_set_the_order_on_the_query_builder(


### PR DESCRIPTION
This is a hotfix for the "v1.11-ALPHA.1". The paginator does not work anymore due to a new "int" typehint for the current page on Pagerfanta 3.