### PR TITLE
[Docs] Remove invalid configuration for grid actions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,28 +81,24 @@ sylius_grid:
                         type: create
                         label: sylius.ui.create
                         enabled: true
-                        icon: ~
                         position: 100
                 item:
                     update:
                         type: update
                         label: sylius.ui.edit
                         enabled: true
-                        icon: ~
                         position: 100
                         options: { }
                     delete:
                         type: delete
                         label: sylius.ui.delete
                         enabled: true
-                        icon: ~
                         position: 100
                         options: { }
                     show:
                         type: show
                         label: sylius.ui.show
                         enabled: true
-                        icon: ~
                         position: 100
                         options:
                             link:
@@ -122,7 +118,6 @@ sylius_grid:
                         type: delete
                         label: sylius.ui.delete
                         enabled: true
-                        icon: ~
                         position: 100
                         options: { }
                 subitem:


### PR DESCRIPTION
If you try to add icons to those actions, it will simply throw an exception since it does not expect null but string:

![image](https://user-images.githubusercontent.com/9363039/154000832-b4d9a055-2e29-46ff-9451-c7671e28fd1b.png)

But even if you define a Semantic icon, it ignores it since the template does not expect it.