### PR TITLE
Deprecate the drivers config node

### DIFF
--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -40,6 +40,7 @@ final class Configuration implements ConfigurationInterface
         $node
             ->children()
                 ->arrayNode('drivers')
+                    ->setDeprecated('sylius/grid-bundle', '1.12', 'The child node "%node%" at path "%path%" is deprecated and will be removed in SyliusGridBundle 2.0. As of SyliusGridBundle 1.12, it is no longer used.')
                     ->defaultValue([SyliusGridBundle::DRIVER_DOCTRINE_ORM])
                     ->enumPrototype()->values(SyliusGridBundle::getAvailableDrivers())->end()
                 ->end()


### PR DESCRIPTION
As suggested in https://github.com/Sylius/SyliusGridBundle/issues/61#issuecomment-1066881862, this deprecates the "drivers" config node in favor of feature detection.  The node only allows values supported by the resource bundle and causes confusion when folks try to create custom drivers (which can be done with the `sylius.grid_driver` tag without adding it to that config node), so it really doesn't offer any benefit to existing.

Instead, Symfony's API for detecting features available at compile time is used.  If an app has both `doctrine/orm` and `doctrine/doctrine-bundle` installed, then the ORM and DBAL drivers will be automatically enabled.  If an app has both `doctrine/phpcr-odm` and `doctrine/phpcr-bundle` installed, the (deprecated) PHPCR-ODM driver will be automatically enabled.  The bundles are included in the dependency list because the driver services have dependencies to services created by the respective bundles, so the presence of the managers alone cannot fulfill the service requirements.

If accepted as is, the "drivers" config node is no longer used by the bundle at all.  I guess this could be a minor inconvenience if someone is using this bundle in an application that has both the ORM and PHPCR-ODM (and their bundles) installed and was using the config to disable one of the drivers, but you can accomplish the same with a compiler pass if needed.

On a side note, to have a full suite of test scenarios that actually makes sure these optional integrations stay optional, the CI would really need to run the tests without each of the Doctrine dependencies installed (similar to the steps in the resource bundle CI), but that's going to be a much larger undertaking (especially for the deprecated PHPCR-ODM integration).