### PR TITLE
[Docs]: fix the correct enabled grid field template

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,7 @@ jobs:
                 name: Restrict Symfony version
                 if: matrix.symfony != ''
                 run: |
+                    composer global config --no-plugins allow-plugins.symfony/flex true
                     composer global require --no-progress --no-scripts --no-plugins "symfony/flex:^1.10"
                     composer config extra.symfony.require "${{ matrix.symfony }}"
                     (cd src/Component && composer config extra.symfony.require "${{ matrix.symfony }}")

--- a/docs/your_first_grid.md
+++ b/docs/your_first_grid.md
@@ -89,7 +89,7 @@ return static function (GridConfig $grid) {
                 ->setLabel('sylius.ui.name')
         )
         ->addField(
-            TwigField::create('enabled', 'SyliusUiBundle:Grid/Field:enabled.html.twig')
+            TwigField::create('enabled', '@SyliusUi/Grid/Field/enabled.html.twig')
                 ->setLabel('sylius.ui.enabled')
         )
     )
@@ -128,7 +128,7 @@ final class AdminSupplierGrid extends AbstractGrid implements ResourceAwareGridI
                     ->setLabel('sylius.ui.name')
             )
             ->addField(
-                TwigField::create('enabled', 'SyliusUiBundle:Grid/Field:enabled.html.twig')
+                TwigField::create('enabled', '@SyliusUi/Grid/Field/enabled.html.twig')
                     ->setLabel('sylius.ui.enabled')
             )
         ;    


### PR DESCRIPTION
I tried to follow the guide on the [https://github.com/Sylius/SyliusGridBundle/blob/1.12/docs/your_first_grid.md](url)
and i think there is an error on the template path.

And i got this error:

![sylius-grid-uibundle-incorrect](https://user-images.githubusercontent.com/39524830/168451857-bd921aab-f879-46ed-86b5-4ce5ab079afa.png)

Fix:
Just replaced `TwigField::create('enabled', 'SyliusUiBundle:Grid/Field:enabled.html.twig')`
By `TwigField::create('enabled', '@SyliusUi/Grid/Field/enabled.html.twig')`
