### PR TITLE
Change filter label type

### DIFF
--- a/src/Bundle/Builder/Filter/Filter.php
+++ b/src/Bundle/Builder/Filter/Filter.php
@@ -19,7 +19,7 @@ final class Filter implements FilterInterface
 
     private string $type;
 
-    private ?string $label = null;
+    private string|bool|null $label = null;
 
     private ?bool $enabled = null;
 
@@ -47,12 +47,12 @@ final class Filter implements FilterInterface
         return $this->name;
     }
 
-    public function getLabel(): ?string
+    public function getLabel(): string|bool|null
     {
         return $this->label;
     }
 
-    public function setLabel(?string $label): FilterInterface
+    public function setLabel(string|bool|null $label): FilterInterface
     {
         $this->label = $label;
 

--- a/src/Bundle/Builder/Filter/FilterInterface.php
+++ b/src/Bundle/Builder/Filter/FilterInterface.php
@@ -19,9 +19,9 @@ interface FilterInterface
 
     public function getName(): string;
 
-    public function getLabel(): ?string;
+    public function getLabel(): string|bool|null;
 
-    public function setLabel(?string $label): self;
+    public function setLabel(string|bool|null $label): self;
 
     public function isEnabled(): bool;
 

--- a/src/Bundle/Tests/DependencyInjection/GridBuilderConfigurationTest.php
+++ b/src/Bundle/Tests/DependencyInjection/GridBuilderConfigurationTest.php
@@ -145,7 +145,18 @@ final class GridBuilderConfigurationTest extends AbstractExtensionTestCase
     public function it_builds_grid_with_filters(): void
     {
         $gridBuilder = GridBuilder::create('app_admin_book', Book::class)
-            ->addFilter(Filter::create('search', 'string'))
+            ->addFilter(
+                Filter::create('search', 'string')
+                ->setLabel('Search'),
+            )
+            ->addFilter(
+                Filter::create('name', 'string')
+                ->setLabel(false),
+            )
+            ->addFilter(
+                Filter::create('language', 'string')
+                ->setLabel(null),
+            )
         ;
 
         $this->load([
@@ -167,6 +178,22 @@ final class GridBuilderConfigurationTest extends AbstractExtensionTestCase
                 'fields' => [],
                 'filters' => [
                     'search' => [
+                        'type' => 'string',
+                        'label' => 'Search',
+                        'enabled' => true,
+                        'position' => 100,
+                        'options' => [],
+                        'form_options' => [],
+                    ],
+                    'name' => [
+                        'type' => 'string',
+                        'label' => false,
+                        'enabled' => true,
+                        'position' => 100,
+                        'options' => [],
+                        'form_options' => [],
+                    ],
+                    'language' => [
                         'type' => 'string',
                         'enabled' => true,
                         'position' => 100,

--- a/src/Bundle/spec/Builder/Filter/FilterSpec.php
+++ b/src/Bundle/spec/Builder/Filter/FilterSpec.php
@@ -40,11 +40,25 @@ final class FilterSpec extends ObjectBehavior
         $this->getLabel()->shouldReturn(null);
     }
 
-    function it_sets_label(): void
+    function it_sets_string_label(): void
     {
         $this->setLabel('Search');
 
         $this->getLabel()->shouldReturn('Search');
+    }
+
+    function it_sets_boolean_label(): void
+    {
+        $this->setLabel(false);
+
+        $this->getLabel()->shouldReturn(false);
+    }
+
+    function it_sets_null_label(): void
+    {
+        $this->setLabel(null);
+
+        $this->getLabel()->shouldReturn(null);
     }
 
     function it_is_enabled_by_default(): void


### PR DESCRIPTION
This PR solves the issue in this other [PR](https://github.com/Sylius/Sylius/pull/14449#issuecomment-1280010188). This allows setting a label value to false and converting a YAML grid configuration to a PHP configuration.

This won't cause issues because `SyliusGridBundle` requires `php:^8.0`.

See https://3v4l.org/gKlHj and https://3v4l.org/4B4cn