### PR TITLE
[WIP] fix: Make criteria work for php grids

### DIFF
--- a/src/Bundle/Builder/Filter/Filter.php
+++ b/src/Bundle/Builder/Filter/Filter.php
@@ -29,7 +29,7 @@ final class Filter implements FilterInterface
 
     private array $formOptions = [];
 
-    private array $criteria = [];
+    private mixed $criteria = [];
 
     private function __construct(string $name, string $type)
     {
@@ -141,12 +141,12 @@ final class Filter implements FilterInterface
         return $this;
     }
 
-    public function getCriteria(): array
+    public function getCriteria(): mixed
     {
         return $this->criteria;
     }
 
-    public function setCriteria(array $criteria): FilterInterface
+    public function setCriteria(mixed $criteria): FilterInterface
     {
         $this->criteria = $criteria;
 
@@ -177,7 +177,7 @@ final class Filter implements FilterInterface
             $output['form_options'] = $this->formOptions;
         }
 
-        if (count($this->criteria) > 0) {
+        if ($this->criteria !== []) {
             $output['criteria'] = $this->criteria;
         }
 

--- a/src/Bundle/Builder/Filter/FilterInterface.php
+++ b/src/Bundle/Builder/Filter/FilterInterface.php
@@ -53,7 +53,7 @@ interface FilterInterface
 
     public function removeFormOption(string $option): self;
 
-    public function setCriteria(array $criteria): self;
+    public function setCriteria(mixed $criteria): self;
 
     public function toArray(): array;
 }

--- a/src/Component/Definition/ArrayToDefinitionConverter.php
+++ b/src/Component/Definition/ArrayToDefinitionConverter.php
@@ -118,8 +118,8 @@ final class ArrayToDefinitionConverter implements ArrayToDefinitionConverterInte
         if (array_key_exists('form_options', $configuration)) {
             $filter->setFormOptions($configuration['form_options']);
         }
-        if (array_key_exists('default_value', $configuration)) {
-            $filter->setCriteria($configuration['default_value']);
+        if (array_key_exists('criteria', $configuration)) {
+            $filter->setCriteria($configuration['criteria']);
         }
 
         return $filter;

--- a/src/Component/Provider/ArrayGridProvider.php
+++ b/src/Component/Provider/ArrayGridProvider.php
@@ -63,6 +63,24 @@ final class ArrayGridProvider implements GridProviderInterface
 
         $gridConfiguration = $this->gridConfigurationRemovalsHandler->handle($gridConfiguration);
 
+        if (isset($gridConfiguration['filters'])) {
+            $gridConfiguration['filters'] = $this->handleFiltersDefaultValue($gridConfiguration['filters']);
+        }
+
         return $this->converter->convert($code, $gridConfiguration);
+    }
+
+    private function handleFiltersDefaultValue(array $filters): array
+    {
+        foreach ($filters as &$filter) {
+            if (false === isset($filter['default_value'])) {
+                continue;
+            }
+
+            $filter['criteria'] = $filter['default_value'];
+            unset($filter['default_value']);
+        }
+
+        return $filters;
     }
 }


### PR DESCRIPTION
Filters in YAML configuration have the option to define a `default_value`. This is not the case for PHP configuration.

But, in the case of YAML, the `default_value` [is eventually used for the criteria in the filter definition](https://github.com/Sylius/SyliusGridBundle/blob/1.12/src/Component/Definition/ArrayToDefinitionConverter.php#L121).

Because of that, the `ArrayToDefinitionConverter` will only work for YAML grids (because PHP grids do not have a `default_value`, but a [`criteria` key in its configuration array](https://github.com/Sylius/SyliusGridBundle/blob/1.12/src/Bundle/Builder/Filter/Filter.php#L180)).

This pull request aims to solve this issue by renaming the `default_value` to `criteria` in the [`ArrayGridProvider`](https://github.com/Sylius/SyliusGridBundle/pull/270/files#diff-d7dc1791e7a24cdca838e3a770c2aaa70435a45a7d67aa2651c2170d5cd66a57R73) for YAML grids and changing the `ArrayToDefintionConverter` so that the `criteria` (not the `default_value`) key is used to set the criteria.

Note that the `criteria` is mixed in the Filter definition, so I changed the type of the `criteria` in the Filter builder to reflect that.