### PR TITLE
Add QueryBuilder access to custom filters

### DIFF
--- a/docs/custom_filter.md
+++ b/docs/custom_filter.md
@@ -10,14 +10,23 @@ To add a new filter, we need to create an appropriate class and form type.
 
 namespace App\Grid\Filter;
 
-use Sylius\Component\Grid\Data\DataSourceInterface;
+use Sylius\Bundle\GridBundle\Doctrine\DataSourceInterface;
 use Sylius\Component\Grid\Filtering\FilterInterface;
 
 class SuppliersStatisticsFilter implements FilterInterface
 {
     public function apply(DataSourceInterface $dataSource, $name, $data, array $options = []): void
     {
-        // Your filtering logic. DataSource is kind of query builder.
+        // Your filtering logic.
+        // $data['stats'] contains the submitted value!
+        // here is an example
+        $queryBuilder = $dataSource->getQueryBuilder();
+        $queryBuilder
+            ->andWhere('stats = :stats')
+            ->setParameter(':stats', $data['stats'])
+        ;
+    
+        // For driver abstraction you can use the expression builder. ExpressionBuilder is kind of query builder.
         // $data['stats'] contains the submitted value!
         // here is an example
         $dataSource->restrict($dataSource->getExpressionBuilder()->equals('stats', $data['stats']));

--- a/src/Bundle/Doctrine/DBAL/DataSource.php
+++ b/src/Bundle/Doctrine/DBAL/DataSource.php
@@ -16,7 +16,7 @@ namespace Sylius\Bundle\GridBundle\Doctrine\DBAL;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Pagerfanta\Doctrine\DBAL\QueryAdapter;
 use Pagerfanta\Pagerfanta;
-use Sylius\Component\Grid\Data\DataSourceInterface;
+use Sylius\Bundle\GridBundle\Doctrine\DataSourceInterface;
 use Sylius\Component\Grid\Data\ExpressionBuilderInterface;
 use Sylius\Component\Grid\Parameters;
 
@@ -44,6 +44,11 @@ final class DataSource implements DataSourceInterface
 
                 break;
         }
+    }
+
+    public function getQueryBuilder(): QueryBuilder
+    {
+        return $this->queryBuilder;
     }
 
     public function getExpressionBuilder(): ExpressionBuilderInterface

--- a/src/Bundle/Doctrine/DataSourceInterface.php
+++ b/src/Bundle/Doctrine/DataSourceInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\GridBundle\Doctrine;
+
+use Doctrine\DBAL\Query\QueryBuilder as DBALQueryBuilder;
+use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder as ODMQueryBuilder;
+use Doctrine\ORM\QueryBuilder as ORMQueryBuilder;
+use Sylius\Component\Grid\Data\DataSourceInterface as BaseDataSourceInterface;
+
+interface DataSourceInterface extends BaseDataSourceInterface
+{
+    public function getQueryBuilder(): ORMQueryBuilder|DBALQueryBuilder|ODMQueryBuilder;
+}

--- a/src/Bundle/Doctrine/ORM/DataSource.php
+++ b/src/Bundle/Doctrine/ORM/DataSource.php
@@ -16,7 +16,7 @@ namespace Sylius\Bundle\GridBundle\Doctrine\ORM;
 use Doctrine\ORM\QueryBuilder;
 use Pagerfanta\Doctrine\ORM\QueryAdapter;
 use Pagerfanta\Pagerfanta;
-use Sylius\Component\Grid\Data\DataSourceInterface;
+use Sylius\Bundle\GridBundle\Doctrine\DataSourceInterface;
 use Sylius\Component\Grid\Data\ExpressionBuilderInterface;
 use Sylius\Component\Grid\Parameters;
 
@@ -58,6 +58,11 @@ final class DataSource implements DataSourceInterface
 
                 break;
         }
+    }
+
+    public function getQueryBuilder(): QueryBuilder
+    {
+        return $this->queryBuilder;
     }
 
     public function getExpressionBuilder(): ExpressionBuilderInterface

--- a/src/Bundle/Doctrine/PHPCRODM/DataSource.php
+++ b/src/Bundle/Doctrine/PHPCRODM/DataSource.php
@@ -16,7 +16,7 @@ namespace Sylius\Bundle\GridBundle\Doctrine\PHPCRODM;
 use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
 use Pagerfanta\Doctrine\PHPCRODM\QueryAdapter;
 use Pagerfanta\Pagerfanta;
-use Sylius\Component\Grid\Data\DataSourceInterface;
+use Sylius\Bundle\GridBundle\Doctrine\DataSourceInterface;
 use Sylius\Component\Grid\Data\ExpressionBuilderInterface;
 use Sylius\Component\Grid\Parameters;
 
@@ -54,6 +54,11 @@ final class DataSource implements DataSourceInterface
 
         $visitor = new ExpressionVisitor($this->queryBuilder);
         $visitor->dispatch($expression, $parentNode);
+    }
+
+    public function getQueryBuilder(): QueryBuilder
+    {
+        return $this->queryBuilder;
     }
 
     public function getExpressionBuilder(): ExpressionBuilderInterface


### PR DESCRIPTION
When we need a filter with a bit more complex query.

As a work-around to handle this, I usually empty the custom filter and handle this into the repository itself by passing the criteria to the repository method but that is not cool.