### PR TITLE
[GridBuilder] Apply transition action

### DIFF
--- a/src/Bundle/Builder/Action/ApplyTransitionAction.php
+++ b/src/Bundle/Builder/Action/ApplyTransitionAction.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\GridBundle\Builder\Action;
+
+final class ApplyTransitionAction
+{
+    public static function create(string $name, string $route, array $routeParameters = [], array $options = []): ActionInterface
+    {
+        $action = Action::create($name, 'apply_transition');
+
+        $options = array_merge([
+            'link' => [
+                'route' => $route,
+                'parameters' => $routeParameters,
+            ],
+            'transition' => $name,
+        ], $options);
+
+        $action->setOptions($options);
+
+        return $action;
+    }
+}

--- a/src/Bundle/spec/Builder/Action/ApplyTransitionActionSpec.php
+++ b/src/Bundle/spec/Builder/Action/ApplyTransitionActionSpec.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\GridBundle\Builder\Action;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\GridBundle\Builder\Action\ActionInterface;
+use Sylius\Bundle\GridBundle\Builder\Action\ApplyTransitionAction;
+
+final class ApplyTransitionActionSpec extends ObjectBehavior
+{
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(ApplyTransitionAction::class);
+    }
+
+    function it_builds_apply_transition_actions(): void
+    {
+        $action = $this::create('publish', 'app_book_publish', ['id' => 'resource.id']);
+
+        $action->shouldHaveType(ActionInterface::class);
+        $action->toArray()->shouldReturn([
+            'type' => 'apply_transition',
+            'options' => [
+                'link' => [
+                    'route' => 'app_book_publish',
+                    'parameters' => ['id' => 'resource.id'],
+                ],
+                'transition' => 'publish',
+            ],
+        ]);
+    }
+
+    function it_builds_apply_transition_with_options(): void
+    {
+        $action = $this::create(
+            'publish',
+            'app_book_publish',
+            [
+                'id' => 'resource.id',
+            ],
+            [
+                'class' => 'green',
+                'graph' => 'sylius_book_publishing',
+            ],
+        );
+
+        $action->shouldHaveType(ActionInterface::class);
+        $action->toArray()->shouldReturn([
+            'type' => 'apply_transition',
+            'options' => [
+                'link' => [
+                    'route' => 'app_book_publish',
+                    'parameters' => ['id' => 'resource.id'],
+                ],
+                'transition' => 'publish',
+                'class' => 'green',
+                'graph' => 'sylius_book_publishing',
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
An helper for this kind of feature:
https://github.com/Sylius/Sylius/blob/1.13/src/Sylius/Bundle/AdminBundle/Resources/config/grids/product_review.yml#L56

I choose not to add "graph" on the action constructor and let the developer add it on the "options" side.
The reason is that is it's not mandatory and Symfony workflow & Winzou state machine have 2 default values (`default` for Winzou and `null` for Symfony workflow).

The current template which is a Winzou specific one.
I do not remember if I've changed sth on that template on my Workflow PoC.

```twig
<!-- @SyliusUi/Grid/Action/applyTransition.html.twig -->

{% set labeled = options.labeled is defined ? options.labeled : true %}

{% if sm_can(data, options.transition, options.graph) %}
    <form action="{{ path(options.link.route, options.link.parameters) }}" method="post">
        <input type="hidden" name="_csrf_token" value="{{ csrf_token(data.id) }}">
        <input type="hidden" name="_method" value="PUT">
        <button class="ui loadable {{ options.class|default }} {% if labeled %}labeled{% endif %} icon button" type="submit" data-js-disable=".sylius-grid-table-wrapper button, .sylius-grid-table-wrapper a">
            <i class="{{ action.icon }} icon"></i>
            {% if labeled %}{{ action.label|trans }}{% endif %}
        </button>
    </form>
{% endif %}
```


I do not like the way "setOptions" has been done (https://github.com/Sylius/SyliusGridBundle/blob/1.13/src/Bundle/Builder/Action/Action.php#L69). I think it's very confusing that it removes the existing values.
I think we should merge the Options for a future version and add a removeOption method instead to remove a specific option.