### PR TITLE
:sparkles: Allow join on ExpressionBuilder comparison

### DIFF
--- a/src/Bundle/Doctrine/ORM/ExpressionBuilder.php
+++ b/src/Bundle/Doctrine/ORM/ExpressionBuilder.php
@@ -40,7 +40,10 @@ final class ExpressionBuilder implements MemberOfAwareExpressionBuilderInterface
 
     public function comparison(string $field, string $operator, $value)
     {
-        return new Comparison($field, $operator, $value);
+        $fieldWithJoin = $this->resolveFieldByAddingJoins($field);
+        $valueWithJoin = $this->resolveFieldByAddingJoins($value);
+
+        return new Comparison($fieldWithJoin, $operator, $valueWithJoin);
     }
 
     public function equals(string $field, $value)


### PR DESCRIPTION
Allowing for the compare method of ExpressionBuilder to join on different table before comparing.

It is currently not possible to compare two fields which are in a joined table.