### PR TITLE
Don't remove driver options when extending a grid configuration

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -4,29 +4,30 @@ use PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer;
 use PhpCsFixer\Fixer\Comment\HeaderCommentFixer;
 use PhpCsFixer\Fixer\Phpdoc\NoSuperfluousPhpdocTagsFixer;
 use SlevomatCodingStandard\Sniffs\Commenting\InlineDocCommentDeclarationSniff;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
-use Symplify\EasyCodingStandard\ValueObject\Option;
 
-return static function (ECSConfig $containerConfigurator): void {
-    $containerConfigurator->import('vendor/sylius-labs/coding-standard/ecs.php');
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->paths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ]);
 
-    $containerConfigurator
-        ->services()
-        ->set(HeaderCommentFixer::class)->call('configure', [[
-            'location' => 'after_open',
-            'header' =>
-'This file is part of the Sylius package.
+    $ecsConfig->import('vendor/sylius-labs/coding-standard/ecs.php');
 
-(c) Paweł Jędrzejewski
+    $ecsConfig->ruleWithConfiguration(HeaderCommentFixer::class, [
+        'location' => 'after_open',
+        'header' =>
+            'This file is part of the Sylius package.
+
+(c) Sylius Sp. z o.o.
 
 For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.',
-        ]])
-        ->set(NoSuperfluousPhpdocTagsFixer::class)->call('configure', [['allow_mixed' => true]])
+    ])
     ;
+    $ecsConfig->ruleWithConfiguration(NoSuperfluousPhpdocTagsFixer::class, ['allow_mixed' => true]);
 
-    $containerConfigurator->parameters()->set(Option::SKIP, [
+    $ecsConfig->skip([
         InlineDocCommentDeclarationSniff::class . '.MissingVariable',
         VisibilityRequiredFixer::class => ['*Spec.php'],
         '**/var/*',

--- a/src/Bundle/Builder/Action/Action.php
+++ b/src/Bundle/Builder/Action/Action.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Builder/Action/ActionInterface.php
+++ b/src/Bundle/Builder/Action/ActionInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Builder/Action/CreateAction.php
+++ b/src/Bundle/Builder/Action/CreateAction.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Builder/Action/DeleteAction.php
+++ b/src/Bundle/Builder/Action/DeleteAction.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Builder/Action/ShowAction.php
+++ b/src/Bundle/Builder/Action/ShowAction.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Builder/Action/UpdateAction.php
+++ b/src/Bundle/Builder/Action/UpdateAction.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Builder/ActionGroup/ActionGroup.php
+++ b/src/Bundle/Builder/ActionGroup/ActionGroup.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Builder/ActionGroup/ActionGroupInterface.php
+++ b/src/Bundle/Builder/ActionGroup/ActionGroupInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Builder/ActionGroup/BulkActionGroup.php
+++ b/src/Bundle/Builder/ActionGroup/BulkActionGroup.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Builder/ActionGroup/ItemActionGroup.php
+++ b/src/Bundle/Builder/ActionGroup/ItemActionGroup.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Builder/ActionGroup/MainActionGroup.php
+++ b/src/Bundle/Builder/ActionGroup/MainActionGroup.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Builder/ActionGroup/SubItemActionGroup.php
+++ b/src/Bundle/Builder/ActionGroup/SubItemActionGroup.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Builder/Field/DateTimeField.php
+++ b/src/Bundle/Builder/Field/DateTimeField.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Builder/Field/Field.php
+++ b/src/Bundle/Builder/Field/Field.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Builder/Field/FieldInterface.php
+++ b/src/Bundle/Builder/Field/FieldInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Builder/Field/StringField.php
+++ b/src/Bundle/Builder/Field/StringField.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Builder/Field/TwigField.php
+++ b/src/Bundle/Builder/Field/TwigField.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Builder/Filter/BooleanFilter.php
+++ b/src/Bundle/Builder/Filter/BooleanFilter.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Builder/Filter/DateFilter.php
+++ b/src/Bundle/Builder/Filter/DateFilter.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Builder/Filter/EntityFilter.php
+++ b/src/Bundle/Builder/Filter/EntityFilter.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Builder/Filter/ExistsFilter.php
+++ b/src/Bundle/Builder/Filter/ExistsFilter.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Builder/Filter/Filter.php
+++ b/src/Bundle/Builder/Filter/Filter.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Builder/Filter/FilterInterface.php
+++ b/src/Bundle/Builder/Filter/FilterInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Builder/Filter/MoneyFilter.php
+++ b/src/Bundle/Builder/Filter/MoneyFilter.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Builder/Filter/SelectFilter.php
+++ b/src/Bundle/Builder/Filter/SelectFilter.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Builder/Filter/StringFilter.php
+++ b/src/Bundle/Builder/Filter/StringFilter.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Builder/GridBuilder.php
+++ b/src/Bundle/Builder/GridBuilder.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -195,8 +195,8 @@ final class GridBuilder implements GridBuilderInterface
     {
         $output = [
             'driver' => [
-            'name' => $this->driver,
-            'options' => $this->driverConfiguration,
+                'name' => $this->driver,
+                'options' => $this->driverConfiguration,
             ],
             'removals' => $this->removals,
         ];

--- a/src/Bundle/Builder/GridBuilder.php
+++ b/src/Bundle/Builder/GridBuilder.php
@@ -196,10 +196,13 @@ final class GridBuilder implements GridBuilderInterface
         $output = [
             'driver' => [
                 'name' => $this->driver,
-                'options' => $this->driverConfiguration,
             ],
             'removals' => $this->removals,
         ];
+
+        if (count($this->driverConfiguration) > 0) {
+            $output['driver']['options'] = $this->driverConfiguration;
+        }
 
         if (count($this->fields) > 0) {
             $output['fields'] = array_map(function (FieldInterface $field) { return $field->toArray(); }, $this->fields);

--- a/src/Bundle/Builder/GridBuilderInterface.php
+++ b/src/Bundle/Builder/GridBuilderInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Command/StubCommand.php
+++ b/src/Bundle/Command/StubCommand.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Command/StubMakeGrid.php
+++ b/src/Bundle/Command/StubMakeGrid.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Config/GridConfig.php
+++ b/src/Bundle/Config/GridConfig.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Config/GridConfigInterface.php
+++ b/src/Bundle/Config/GridConfigInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/DependencyInjection/Compiler/RegisterDriversPass.php
+++ b/src/Bundle/DependencyInjection/Compiler/RegisterDriversPass.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/DependencyInjection/Compiler/RegisterFieldTypesPass.php
+++ b/src/Bundle/DependencyInjection/Compiler/RegisterFieldTypesPass.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/DependencyInjection/Compiler/RegisterFiltersPass.php
+++ b/src/Bundle/DependencyInjection/Compiler/RegisterFiltersPass.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/DependencyInjection/Compiler/RegisterStubCommandsPass.php
+++ b/src/Bundle/DependencyInjection/Compiler/RegisterStubCommandsPass.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/DependencyInjection/SyliusGridExtension.php
+++ b/src/Bundle/DependencyInjection/SyliusGridExtension.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Doctrine/DBAL/DataSource.php
+++ b/src/Bundle/Doctrine/DBAL/DataSource.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Doctrine/DBAL/Driver.php
+++ b/src/Bundle/Doctrine/DBAL/Driver.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Doctrine/DBAL/ExpressionBuilder.php
+++ b/src/Bundle/Doctrine/DBAL/ExpressionBuilder.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Doctrine/ORM/DataSource.php
+++ b/src/Bundle/Doctrine/ORM/DataSource.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Doctrine/ORM/Driver.php
+++ b/src/Bundle/Doctrine/ORM/Driver.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Doctrine/ORM/ExpressionBuilder.php
+++ b/src/Bundle/Doctrine/ORM/ExpressionBuilder.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Doctrine/PHPCRODM/DataSource.php
+++ b/src/Bundle/Doctrine/PHPCRODM/DataSource.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Doctrine/PHPCRODM/Driver.php
+++ b/src/Bundle/Doctrine/PHPCRODM/Driver.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Doctrine/PHPCRODM/ExpressionBuilder.php
+++ b/src/Bundle/Doctrine/PHPCRODM/ExpressionBuilder.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Doctrine/PHPCRODM/ExpressionBuilderInterface.php
+++ b/src/Bundle/Doctrine/PHPCRODM/ExpressionBuilderInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Doctrine/PHPCRODM/ExpressionVisitor.php
+++ b/src/Bundle/Doctrine/PHPCRODM/ExpressionVisitor.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Doctrine/PHPCRODM/ExtraComparison.php
+++ b/src/Bundle/Doctrine/PHPCRODM/ExtraComparison.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/FieldTypes/TwigFieldType.php
+++ b/src/Bundle/FieldTypes/TwigFieldType.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Form/DataTransformer/DateTimeFilterTransformer.php
+++ b/src/Bundle/Form/DataTransformer/DateTimeFilterTransformer.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Form/Registry/FormTypeRegistry.php
+++ b/src/Bundle/Form/Registry/FormTypeRegistry.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Form/Registry/FormTypeRegistryInterface.php
+++ b/src/Bundle/Form/Registry/FormTypeRegistryInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Form/Type/Filter/BooleanFilterType.php
+++ b/src/Bundle/Form/Type/Filter/BooleanFilterType.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Form/Type/Filter/DateFilterType.php
+++ b/src/Bundle/Form/Type/Filter/DateFilterType.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Form/Type/Filter/EntityFilterType.php
+++ b/src/Bundle/Form/Type/Filter/EntityFilterType.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Form/Type/Filter/ExistsFilterType.php
+++ b/src/Bundle/Form/Type/Filter/ExistsFilterType.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Form/Type/Filter/MoneyFilterType.php
+++ b/src/Bundle/Form/Type/Filter/MoneyFilterType.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Form/Type/Filter/SelectFilterType.php
+++ b/src/Bundle/Form/Type/Filter/SelectFilterType.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Form/Type/Filter/StringFilterType.php
+++ b/src/Bundle/Form/Type/Filter/StringFilterType.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Grid/AbstractGrid.php
+++ b/src/Bundle/Grid/AbstractGrid.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Grid/GridInterface.php
+++ b/src/Bundle/Grid/GridInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Grid/ResourceAwareGridInterface.php
+++ b/src/Bundle/Grid/ResourceAwareGridInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Maker/MakeGrid.php
+++ b/src/Bundle/Maker/MakeGrid.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Provider/ServiceGridProvider.php
+++ b/src/Bundle/Provider/ServiceGridProvider.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Registry/GridRegistry.php
+++ b/src/Bundle/Registry/GridRegistry.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Registry/GridRegistryInterface.php
+++ b/src/Bundle/Registry/GridRegistryInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Renderer/TwigBulkActionGridRenderer.php
+++ b/src/Bundle/Renderer/TwigBulkActionGridRenderer.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Renderer/TwigGridRenderer.php
+++ b/src/Bundle/Renderer/TwigGridRenderer.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/SyliusGridBundle.php
+++ b/src/Bundle/SyliusGridBundle.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Templating/Helper/BulkActionGridHelper.php
+++ b/src/Bundle/Templating/Helper/BulkActionGridHelper.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Templating/Helper/GridHelper.php
+++ b/src/Bundle/Templating/Helper/GridHelper.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Tests/DependencyInjection/Compiler/RegisterDriversPassTest.php
+++ b/src/Bundle/Tests/DependencyInjection/Compiler/RegisterDriversPassTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Tests/DependencyInjection/Compiler/RegisterFieldTypesPassTest.php
+++ b/src/Bundle/Tests/DependencyInjection/Compiler/RegisterFieldTypesPassTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Tests/DependencyInjection/Compiler/RegisterFiltersPassTest.php
+++ b/src/Bundle/Tests/DependencyInjection/Compiler/RegisterFiltersPassTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Tests/DependencyInjection/Compiler/RegisterStubCommandsPassTest.php
+++ b/src/Bundle/Tests/DependencyInjection/Compiler/RegisterStubCommandsPassTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Bundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Tests/DependencyInjection/GridBuilderConfigurationTest.php
+++ b/src/Bundle/Tests/DependencyInjection/GridBuilderConfigurationTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Tests/DependencyInjection/SyliusGridExtensionTest.php
+++ b/src/Bundle/Tests/DependencyInjection/SyliusGridExtensionTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Tests/Functional/Command/StubMakeGridTest.php
+++ b/src/Bundle/Tests/Functional/Command/StubMakeGridTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Tests/Functional/GridApiTest.php
+++ b/src/Bundle/Tests/Functional/GridApiTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Tests/Functional/Maker/MakeGridTest.php
+++ b/src/Bundle/Tests/Functional/Maker/MakeGridTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -121,8 +121,8 @@ use Sylius\Bundle\GridBundle\Builder\Field\DateTimeField;
 use Sylius\Bundle\GridBundle\Builder\Field\StringField;
 use Sylius\Bundle\GridBundle\Builder\Field\TwigField;
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\ResourceAwareGridInterface;
 use Sylius\Bundle\GridBundle\Grid\AbstractGrid;
+use Sylius\Bundle\GridBundle\Grid\ResourceAwareGridInterface;
 
 final class BookGrid extends AbstractGrid implements ResourceAwareGridInterface
 {
@@ -150,10 +150,10 @@ final class BookGrid extends AbstractGrid implements ResourceAwareGridInterface
                     ->setLabel('State')
                     ->setSortable(true)
             )
-            //->addField(
+            // ->addField(
             //    TwigField::create('enabled', 'path/to/field/template.html.twig')
             //        ->setLabel('Enabled')
-            //)
+            // )
             ->addField(
                 DateTimeField::create('createdAt')
                     ->setLabel('CreatedAt')
@@ -216,12 +216,10 @@ use Sylius\Bundle\GridBundle\Builder\Action\UpdateAction;
 use Sylius\Bundle\GridBundle\Builder\ActionGroup\BulkActionGroup;
 use Sylius\Bundle\GridBundle\Builder\ActionGroup\ItemActionGroup;
 use Sylius\Bundle\GridBundle\Builder\ActionGroup\MainActionGroup;
-use Sylius\Bundle\GridBundle\Builder\Field\DateTimeField;
 use Sylius\Bundle\GridBundle\Builder\Field\StringField;
-use Sylius\Bundle\GridBundle\Builder\Field\TwigField;
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\ResourceAwareGridInterface;
 use Sylius\Bundle\GridBundle\Grid\AbstractGrid;
+use Sylius\Bundle\GridBundle\Grid\ResourceAwareGridInterface;
 
 final class PriceGrid extends AbstractGrid implements ResourceAwareGridInterface
 {
@@ -289,12 +287,10 @@ use Sylius\Bundle\GridBundle\Builder\Action\UpdateAction;
 use Sylius\Bundle\GridBundle\Builder\ActionGroup\BulkActionGroup;
 use Sylius\Bundle\GridBundle\Builder\ActionGroup\ItemActionGroup;
 use Sylius\Bundle\GridBundle\Builder\ActionGroup\MainActionGroup;
-use Sylius\Bundle\GridBundle\Builder\Field\DateTimeField;
 use Sylius\Bundle\GridBundle\Builder\Field\StringField;
-use Sylius\Bundle\GridBundle\Builder\Field\TwigField;
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\ResourceAwareGridInterface;
 use Sylius\Bundle\GridBundle\Grid\AbstractGrid;
+use Sylius\Bundle\GridBundle\Grid\ResourceAwareGridInterface;
 
 final class AdminUserGrid extends AbstractGrid implements ResourceAwareGridInterface
 {

--- a/src/Bundle/Tests/Functional/Maker/MakerTestCase.php
+++ b/src/Bundle/Tests/Functional/Maker/MakerTestCase.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Tests/Functional/PaginationTest.php
+++ b/src/Bundle/Tests/Functional/PaginationTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Tests/Functional/SortingTest.php
+++ b/src/Bundle/Tests/Functional/SortingTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Tests/Provider/ServiceGridProviderTest.php
+++ b/src/Bundle/Tests/Provider/ServiceGridProviderTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Tests/SyliusGridBundleTest.php
+++ b/src/Bundle/Tests/SyliusGridBundleTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Twig/BulkActionGridExtension.php
+++ b/src/Bundle/Twig/BulkActionGridExtension.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/Twig/GridExtension.php
+++ b/src/Bundle/Twig/GridExtension.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Builder/Action/ActionSpec.php
+++ b/src/Bundle/spec/Builder/Action/ActionSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Builder/Action/CreateActionSpec.php
+++ b/src/Bundle/spec/Builder/Action/CreateActionSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Builder/Action/DeleteActionSpec.php
+++ b/src/Bundle/spec/Builder/Action/DeleteActionSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Builder/Action/ShowActionSpec.php
+++ b/src/Bundle/spec/Builder/Action/ShowActionSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Builder/Action/UpdateActionSpec.php
+++ b/src/Bundle/spec/Builder/Action/UpdateActionSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Builder/ActionGroup/ActionGroupSpec.php
+++ b/src/Bundle/spec/Builder/ActionGroup/ActionGroupSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Builder/ActionGroup/BulkActionGroupSpec.php
+++ b/src/Bundle/spec/Builder/ActionGroup/BulkActionGroupSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Builder/ActionGroup/ItemActionGroupSpec.php
+++ b/src/Bundle/spec/Builder/ActionGroup/ItemActionGroupSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Builder/ActionGroup/MainActionGroupSpec.php
+++ b/src/Bundle/spec/Builder/ActionGroup/MainActionGroupSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Builder/ActionGroup/SubItemActionGroupSpec.php
+++ b/src/Bundle/spec/Builder/ActionGroup/SubItemActionGroupSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Builder/Field/DateTimeFieldSpec.php
+++ b/src/Bundle/spec/Builder/Field/DateTimeFieldSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Builder/Field/FieldSpec.php
+++ b/src/Bundle/spec/Builder/Field/FieldSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Builder/Field/StringFieldSpec.php
+++ b/src/Bundle/spec/Builder/Field/StringFieldSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Builder/Field/TwigFieldSpec.php
+++ b/src/Bundle/spec/Builder/Field/TwigFieldSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Builder/Filter/BooleanFilterSpec.php
+++ b/src/Bundle/spec/Builder/Filter/BooleanFilterSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Builder/Filter/DateFilterSpec.php
+++ b/src/Bundle/spec/Builder/Filter/DateFilterSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Builder/Filter/EntityFilterSpec.php
+++ b/src/Bundle/spec/Builder/Filter/EntityFilterSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Builder/Filter/ExistsFilterSpec.php
+++ b/src/Bundle/spec/Builder/Filter/ExistsFilterSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Builder/Filter/FilterSpec.php
+++ b/src/Bundle/spec/Builder/Filter/FilterSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Builder/Filter/MoneyFilterSpec.php
+++ b/src/Bundle/spec/Builder/Filter/MoneyFilterSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Builder/Filter/SelectFilterSpec.php
+++ b/src/Bundle/spec/Builder/Filter/SelectFilterSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Builder/Filter/StringFilterSpec.php
+++ b/src/Bundle/spec/Builder/Filter/StringFilterSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Builder/GridBuilderSpec.php
+++ b/src/Bundle/spec/Builder/GridBuilderSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Config/GridConfigSpec.php
+++ b/src/Bundle/spec/Config/GridConfigSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Doctrine/DBAL/DataSourceSpec.php
+++ b/src/Bundle/spec/Doctrine/DBAL/DataSourceSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Doctrine/ORM/DataSourceSpec.php
+++ b/src/Bundle/spec/Doctrine/ORM/DataSourceSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Doctrine/ORM/DriverSpec.php
+++ b/src/Bundle/spec/Doctrine/ORM/DriverSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Doctrine/PHPCRODM/DataSourceSpec.php
+++ b/src/Bundle/spec/Doctrine/PHPCRODM/DataSourceSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Doctrine/PHPCRODM/DriverSpec.php
+++ b/src/Bundle/spec/Doctrine/PHPCRODM/DriverSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Doctrine/PHPCRODM/ExpressionBuilderSpec.php
+++ b/src/Bundle/spec/Doctrine/PHPCRODM/ExpressionBuilderSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/FieldTypes/TwigFieldTypeSpec.php
+++ b/src/Bundle/spec/FieldTypes/TwigFieldTypeSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Provider/ServiceGridProviderSpec.php
+++ b/src/Bundle/spec/Provider/ServiceGridProviderSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Registry/GridRegistrySpec.php
+++ b/src/Bundle/spec/Registry/GridRegistrySpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Renderer/TwigBulkActionGridRendererSpec.php
+++ b/src/Bundle/spec/Renderer/TwigBulkActionGridRendererSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Renderer/TwigGridRendererSpec.php
+++ b/src/Bundle/spec/Renderer/TwigGridRendererSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Templating/Helper/BulkActionGridHelperSpec.php
+++ b/src/Bundle/spec/Templating/Helper/BulkActionGridHelperSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/spec/Templating/Helper/GridHelperSpec.php
+++ b/src/Bundle/spec/Templating/Helper/GridHelperSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/config/bootstrap.php
+++ b/src/Bundle/test/config/bootstrap.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/config/bundles.php
+++ b/src/Bundle/test/config/bundles.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/config/sylius/grids/author.php
+++ b/src/Bundle/test/config/sylius/grids/author.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/config/sylius/grids/author_with_books_with_fetch_join_collection_disabled.php
+++ b/src/Bundle/test/config/sylius/grids/author_with_books_with_fetch_join_collection_disabled.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/config/sylius/grids/author_with_books_with_fetch_join_collection_enabled.php
+++ b/src/Bundle/test/config/sylius/grids/author_with_books_with_fetch_join_collection_enabled.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/config/sylius/grids/author_with_books_with_use_output_walkers_disabled.php
+++ b/src/Bundle/test/config/sylius/grids/author_with_books_with_use_output_walkers_disabled.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/config/sylius/grids/author_with_books_with_use_output_walkers_enabled.php
+++ b/src/Bundle/test/config/sylius/grids/author_with_books_with_use_output_walkers_enabled.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/config/sylius/grids/book.php
+++ b/src/Bundle/test/config/sylius/grids/book.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/config/sylius/grids/book_by_amercian_authors.php
+++ b/src/Bundle/test/config/sylius/grids/book_by_amercian_authors.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/config/sylius/grids/book_by_english_authors.php
+++ b/src/Bundle/test/config/sylius/grids/book_by_english_authors.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/src/Driver/Foo.php
+++ b/src/Bundle/test/src/Driver/Foo.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/src/Entity/AdminUser.php
+++ b/src/Bundle/test/src/Entity/AdminUser.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/src/Entity/Author.php
+++ b/src/Bundle/test/src/Entity/Author.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/src/Entity/Book.php
+++ b/src/Bundle/test/src/Entity/Book.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/src/Entity/Nationality.php
+++ b/src/Bundle/test/src/Entity/Nationality.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/src/Entity/Price.php
+++ b/src/Bundle/test/src/Entity/Price.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/src/FieldTypes/FooType.php
+++ b/src/Bundle/test/src/FieldTypes/FooType.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/src/Filter/Foo.php
+++ b/src/Bundle/test/src/Filter/Foo.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/src/Grid/AuthorGrid.php
+++ b/src/Bundle/test/src/Grid/AuthorGrid.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/src/Grid/AuthorWithBooksWithFetchJoinCollectionDisabled.php
+++ b/src/Bundle/test/src/Grid/AuthorWithBooksWithFetchJoinCollectionDisabled.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/src/Grid/AuthorWithBooksWithFetchJoinCollectionEnabled.php
+++ b/src/Bundle/test/src/Grid/AuthorWithBooksWithFetchJoinCollectionEnabled.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/src/Grid/AuthorWithBooksWithUseOutputWalkersDisabled.php
+++ b/src/Bundle/test/src/Grid/AuthorWithBooksWithUseOutputWalkersDisabled.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/src/Grid/AuthorWithBooksWithUseOutputWalkersEnabled.php
+++ b/src/Bundle/test/src/Grid/AuthorWithBooksWithUseOutputWalkersEnabled.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/src/Grid/BookByAmericanAuthorsGrid.php
+++ b/src/Bundle/test/src/Grid/BookByAmericanAuthorsGrid.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/src/Grid/BookByEnglishAuthorsGrid.php
+++ b/src/Bundle/test/src/Grid/BookByEnglishAuthorsGrid.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/src/Grid/BookGrid.php
+++ b/src/Bundle/test/src/Grid/BookGrid.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/src/Grid/BookmarkGrid.php
+++ b/src/Bundle/test/src/Grid/BookmarkGrid.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/src/Kernel.php
+++ b/src/Bundle/test/src/Kernel.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/src/QueryBuilder/AuthorsWithBooksQueryBuilder.php
+++ b/src/Bundle/test/src/QueryBuilder/AuthorsWithBooksQueryBuilder.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/src/QueryBuilder/EnglishBooksQueryBuilder.php
+++ b/src/Bundle/test/src/QueryBuilder/EnglishBooksQueryBuilder.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Bundle/test/src/Repository/BookRepository.php
+++ b/src/Bundle/test/src/Repository/BookRepository.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Configuration/GridConfigurationExtender.php
+++ b/src/Component/Configuration/GridConfigurationExtender.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Configuration/GridConfigurationExtenderInterface.php
+++ b/src/Component/Configuration/GridConfigurationExtenderInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Configuration/GridConfigurationRemovalsHandler.php
+++ b/src/Component/Configuration/GridConfigurationRemovalsHandler.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Configuration/GridConfigurationRemovalsHandlerInterface.php
+++ b/src/Component/Configuration/GridConfigurationRemovalsHandlerInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Data/DataProvider.php
+++ b/src/Component/Data/DataProvider.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Data/DataProviderInterface.php
+++ b/src/Component/Data/DataProviderInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Data/DataSourceInterface.php
+++ b/src/Component/Data/DataSourceInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Data/DataSourceProvider.php
+++ b/src/Component/Data/DataSourceProvider.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Data/DataSourceProviderInterface.php
+++ b/src/Component/Data/DataSourceProviderInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Data/DriverInterface.php
+++ b/src/Component/Data/DriverInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Data/ExpressionBuilderInterface.php
+++ b/src/Component/Data/ExpressionBuilderInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Data/UnsupportedDriverException.php
+++ b/src/Component/Data/UnsupportedDriverException.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/DataExtractor/DataExtractorInterface.php
+++ b/src/Component/DataExtractor/DataExtractorInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/DataExtractor/PropertyAccessDataExtractor.php
+++ b/src/Component/DataExtractor/PropertyAccessDataExtractor.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Definition/Action.php
+++ b/src/Component/Definition/Action.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Definition/ActionGroup.php
+++ b/src/Component/Definition/ActionGroup.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Definition/ArrayToDefinitionConverter.php
+++ b/src/Component/Definition/ArrayToDefinitionConverter.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Definition/ArrayToDefinitionConverterInterface.php
+++ b/src/Component/Definition/ArrayToDefinitionConverterInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Definition/Field.php
+++ b/src/Component/Definition/Field.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Definition/Filter.php
+++ b/src/Component/Definition/Filter.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Definition/Grid.php
+++ b/src/Component/Definition/Grid.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Event/GridDefinitionConverterEvent.php
+++ b/src/Component/Event/GridDefinitionConverterEvent.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Exception/UndefinedGridException.php
+++ b/src/Component/Exception/UndefinedGridException.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/FieldTypes/DatetimeFieldType.php
+++ b/src/Component/FieldTypes/DatetimeFieldType.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/FieldTypes/FieldTypeInterface.php
+++ b/src/Component/FieldTypes/FieldTypeInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/FieldTypes/StringFieldType.php
+++ b/src/Component/FieldTypes/StringFieldType.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Filter/BooleanFilter.php
+++ b/src/Component/Filter/BooleanFilter.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Filter/DateFilter.php
+++ b/src/Component/Filter/DateFilter.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Filter/EntityFilter.php
+++ b/src/Component/Filter/EntityFilter.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Filter/ExistsFilter.php
+++ b/src/Component/Filter/ExistsFilter.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Filter/MoneyFilter.php
+++ b/src/Component/Filter/MoneyFilter.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Filter/SelectFilter.php
+++ b/src/Component/Filter/SelectFilter.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Filter/StringFilter.php
+++ b/src/Component/Filter/StringFilter.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Filtering/FilterInterface.php
+++ b/src/Component/Filtering/FilterInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Filtering/FiltersApplicator.php
+++ b/src/Component/Filtering/FiltersApplicator.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Filtering/FiltersApplicatorInterface.php
+++ b/src/Component/Filtering/FiltersApplicatorInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Filtering/FiltersCriteriaResolver.php
+++ b/src/Component/Filtering/FiltersCriteriaResolver.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Filtering/FiltersCriteriaResolverInterface.php
+++ b/src/Component/Filtering/FiltersCriteriaResolverInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Parameters.php
+++ b/src/Component/Parameters.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Provider/ArrayGridProvider.php
+++ b/src/Component/Provider/ArrayGridProvider.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Provider/ChainProvider.php
+++ b/src/Component/Provider/ChainProvider.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Provider/GridProviderInterface.php
+++ b/src/Component/Provider/GridProviderInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Renderer/BulkActionGridRendererInterface.php
+++ b/src/Component/Renderer/BulkActionGridRendererInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Renderer/GridRendererInterface.php
+++ b/src/Component/Renderer/GridRendererInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Sorting/Sorter.php
+++ b/src/Component/Sorting/Sorter.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Sorting/SorterInterface.php
+++ b/src/Component/Sorting/SorterInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Tests/Dummy/Bar.php
+++ b/src/Component/Tests/Dummy/Bar.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Tests/Dummy/BarGrid.php
+++ b/src/Component/Tests/Dummy/BarGrid.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Tests/Dummy/ClassAsParameterGrid.php
+++ b/src/Component/Tests/Dummy/ClassAsParameterGrid.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Tests/Dummy/Foo.php
+++ b/src/Component/Tests/Dummy/Foo.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Tests/Dummy/FooFightersGrid.php
+++ b/src/Component/Tests/Dummy/FooFightersGrid.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Tests/Dummy/FooGrid.php
+++ b/src/Component/Tests/Dummy/FooGrid.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Tests/Dummy/NoResourceGrid.php
+++ b/src/Component/Tests/Dummy/NoResourceGrid.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Validation/FieldValidator.php
+++ b/src/Component/Validation/FieldValidator.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Validation/FieldValidatorInterface.php
+++ b/src/Component/Validation/FieldValidatorInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Validation/SortingParametersValidator.php
+++ b/src/Component/Validation/SortingParametersValidator.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/Validation/SortingParametersValidatorInterface.php
+++ b/src/Component/Validation/SortingParametersValidatorInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/View/GridView.php
+++ b/src/Component/View/GridView.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/View/GridViewFactory.php
+++ b/src/Component/View/GridViewFactory.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/View/GridViewFactoryInterface.php
+++ b/src/Component/View/GridViewFactoryInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/View/GridViewInterface.php
+++ b/src/Component/View/GridViewInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/phpspec/bootstrap.php
+++ b/src/Component/phpspec/bootstrap.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/Configuration/GridConfigurationExtenderSpec.php
+++ b/src/Component/spec/Configuration/GridConfigurationExtenderSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/Configuration/GridConfigurationRemovalsHandlerSpec.php
+++ b/src/Component/spec/Configuration/GridConfigurationRemovalsHandlerSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/Data/DataProviderSpec.php
+++ b/src/Component/spec/Data/DataProviderSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/Data/DataSourceProviderSpec.php
+++ b/src/Component/spec/Data/DataSourceProviderSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/DataExtractor/PropertyAccessDataExtractorSpec.php
+++ b/src/Component/spec/DataExtractor/PropertyAccessDataExtractorSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/Definition/ActionGroupSpec.php
+++ b/src/Component/spec/Definition/ActionGroupSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/Definition/ActionSpec.php
+++ b/src/Component/spec/Definition/ActionSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/Definition/ArrayToDefinitionConverterSpec.php
+++ b/src/Component/spec/Definition/ArrayToDefinitionConverterSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/Definition/FieldSpec.php
+++ b/src/Component/spec/Definition/FieldSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/Definition/FilterSpec.php
+++ b/src/Component/spec/Definition/FilterSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/Definition/GridSpec.php
+++ b/src/Component/spec/Definition/GridSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/Event/GridDefinitionConverterEventSpec.php
+++ b/src/Component/spec/Event/GridDefinitionConverterEventSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/FieldTypes/DatetimeFieldTypeSpec.php
+++ b/src/Component/spec/FieldTypes/DatetimeFieldTypeSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/FieldTypes/StringFieldTypeSpec.php
+++ b/src/Component/spec/FieldTypes/StringFieldTypeSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/Filter/BooleanFilterSpec.php
+++ b/src/Component/spec/Filter/BooleanFilterSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/Filter/DateFilterSpec.php
+++ b/src/Component/spec/Filter/DateFilterSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/Filter/EntityFilterSpec.php
+++ b/src/Component/spec/Filter/EntityFilterSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/Filter/ExistsFilterSpec.php
+++ b/src/Component/spec/Filter/ExistsFilterSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/Filter/MoneyFilterSpec.php
+++ b/src/Component/spec/Filter/MoneyFilterSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/Filter/SelectFilterSpec.php
+++ b/src/Component/spec/Filter/SelectFilterSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/Filter/StringFilterSpec.php
+++ b/src/Component/spec/Filter/StringFilterSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/Filtering/FiltersApplicatorSpec.php
+++ b/src/Component/spec/Filtering/FiltersApplicatorSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/Filtering/FiltersCriteriaResolverSpec.php
+++ b/src/Component/spec/Filtering/FiltersCriteriaResolverSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/Provider/ArrayGridProviderSpec.php
+++ b/src/Component/spec/Provider/ArrayGridProviderSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/Provider/ChainProviderSpec.php
+++ b/src/Component/spec/Provider/ChainProviderSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/Sorting/SorterSpec.php
+++ b/src/Component/spec/Sorting/SorterSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/Validation/FieldValidatorSpec.php
+++ b/src/Component/spec/Validation/FieldValidatorSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/Validation/SortingParametersValidatorSpec.php
+++ b/src/Component/spec/Validation/SortingParametersValidatorSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/View/GridViewFactorySpec.php
+++ b/src/Component/spec/View/GridViewFactorySpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Component/spec/View/GridViewSpec.php
+++ b/src/Component/spec/View/GridViewSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.


### PR DESCRIPTION
Based on #317 

```php
<?php

use App\Entity\Suplier;
use Sylius\Bundle\GridBundle\Builder\GridBuilder;
use Sylius\Bundle\GridBundle\Config\GridConfig;

return static function (GridConfig $grid) {
    $grid->addGrid(
        GridBuilder::create('sylius_admin_product_variant')
    );
};

```

When running this following command:
```bash
$ bin/console debug:config sylius_grid grids.sylius_admin_product_variant.driver
```

Before
```yaml
name: doctrine/orm
options: {  }
```

After
```yaml
name: doctrine/orm
options:
    class: App\Entity\Product\ProductVariant
    repository:
        method: createQueryBuilderByProductId
        arguments:
            - "expr:service('sylius.context.locale').getLocaleCode()"
            - $productId
```