### PR TITLE
Add timezone option to DatetimeFieldType

### DIFF
--- a/docs/field_types.md
+++ b/docs/field_types.md
@@ -104,7 +104,7 @@ This column type works exactly the same way as *string*, but expects
 
 Available options:
 * `format` - default is `Y:m:d H:i:s`, you can modify it with any supported format (see https://www.php.net/manual/en/datetime.format.php)
-* `timezone` - default is `%timezone%` parameter, null if such a parameter does not exist, you can modify it with any supported timezone (see https://www.php.net/manual/en/timezones.php)
+* `timezone` - default is `%sylius_grid.timezone%` parameter, null if such a parameter does not exist, you can modify it with any supported timezone (see https://www.php.net/manual/en/timezones.php)
 
 <details open><summary>Yaml</summary>
 

--- a/docs/field_types.md
+++ b/docs/field_types.md
@@ -102,6 +102,10 @@ DateTime
 This column type works exactly the same way as *string*, but expects
 *DateTime* instance and outputs a formatted date and time string.
 
+Available options:
+* `format` - default is `Y:m:d H:i:s`, you can modify it with any supported format (see https://www.php.net/manual/en/datetime.format.php)
+* `timezone` - default is `%timezone%` parameter, null if such a parameter does not exist, you can modify it with any supported timezone (see https://www.php.net/manual/en/timezones.php)
+
 <details open><summary>Yaml</summary>
 
 ```yaml
@@ -115,7 +119,8 @@ sylius_grid:
                     type: datetime
                     label: app.ui.birthday
                     options:
-                        format: 'Y:m:d H:i:s' # this is the default value, but you can modify it
+                        format: 'Y:m:d H:i:s'
+                        timezone: null
 ```
 
 </details>
@@ -133,7 +138,7 @@ use Sylius\Bundle\GridBundle\Config\GridConfig;
 return static function (GridConfig $grid): void {
     $grid->addGrid(GridBuilder::create('app_user', '%app.model.user.class%')
         ->addField(
-            DateTimeField::create('birthday', 'Y:m:d H:i:s') // this format is the default value, but you can modify it
+            DateTimeField::create('birthday', 'Y:m:d H:i:s', null) // this format and timezone are the default value, but you can modify it
                 ->setLabel('app.ui.birthday')
         )
     )
@@ -167,7 +172,7 @@ final class UserGrid extends AbstractGrid implements ResourceAwareGridInterface
     {
         $gridBuilder
             ->addField(
-                DateTimeField::create('birthday', 'Y:m:d H:i:s') // this format is the default value, but you can modify it
+                DateTimeField::create('birthday', 'Y:m:d H:i:s', null) // this format and timezone are the default value, but you can modify it
                     ->setLabel('app.ui.birthday')
             )
         ;
@@ -184,13 +189,15 @@ final class UserGrid extends AbstractGrid implements ResourceAwareGridInterface
 
 ### *Warning*
 
-You have to pass the `'format'` again if you want to call the `setOptions` function. Otherwise it will be unset:
+You have to pass `'format'` and `'timezone'` again if you want to call the `setOptions` function.
+Otherwise, it will be unset:
 
 Example:
 
 ```php
 $field->setOptions([
     'format' => 'Y-m-d H:i:s',
+    'timezone' => 'null'
 
     // Your options here
 ]);

--- a/src/Bundle/Builder/Field/DateTimeField.php
+++ b/src/Bundle/Builder/Field/DateTimeField.php
@@ -15,10 +15,10 @@ namespace Sylius\Bundle\GridBundle\Builder\Field;
 
 final class DateTimeField
 {
-    public static function create(string $name, string $format = 'Y-m-d H:i:s'): FieldInterface
+    public static function create(string $name, string $format = 'Y-m-d H:i:s', ?string $timezone = null): FieldInterface
     {
         return Field::create($name, 'datetime')
-            ->setOptions(['format' => $format])
+            ->setOptions(['format' => $format, 'timezone' => $timezone])
         ;
     }
 }

--- a/src/Bundle/DependencyInjection/Compiler/RegisterTimezoneParameterPass.php
+++ b/src/Bundle/DependencyInjection/Compiler/RegisterTimezoneParameterPass.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\GridBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class RegisterTimezoneParameterPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if ($container->hasParameter('timezone')) {
+            return;
+        }
+
+        $container->setParameter('timezone', null);
+    }
+}

--- a/src/Bundle/DependencyInjection/Compiler/RegisterTimezoneParameterPass.php
+++ b/src/Bundle/DependencyInjection/Compiler/RegisterTimezoneParameterPass.php
@@ -20,10 +20,10 @@ final class RegisterTimezoneParameterPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        if ($container->hasParameter('timezone')) {
+        if ($container->hasParameter('sylius_grid.timezone')) {
             return;
         }
 
-        $container->setParameter('timezone', null);
+        $container->setParameter('sylius_grid.timezone', null);
     }
 }

--- a/src/Bundle/Resources/config/services/field_types.xml
+++ b/src/Bundle/Resources/config/services/field_types.xml
@@ -17,7 +17,7 @@
 
         <service id="Sylius\Component\Grid\FieldTypes\DatetimeFieldType">
             <argument type="service" id="sylius.grid.data_extractor" />
-            <argument on-invalid="null">%timezone%</argument>
+            <argument>%timezone%</argument>
             <tag name="sylius.grid_field" type="datetime" />
         </service>
         <service id="sylius.grid_field.datetime" alias="Sylius\Component\Grid\FieldTypes\DatetimeFieldType" />

--- a/src/Bundle/Resources/config/services/field_types.xml
+++ b/src/Bundle/Resources/config/services/field_types.xml
@@ -17,6 +17,7 @@
 
         <service id="Sylius\Component\Grid\FieldTypes\DatetimeFieldType">
             <argument type="service" id="sylius.grid.data_extractor" />
+            <argument on-invalid="null">%timezone%</argument>
             <tag name="sylius.grid_field" type="datetime" />
         </service>
         <service id="sylius.grid_field.datetime" alias="Sylius\Component\Grid\FieldTypes\DatetimeFieldType" />

--- a/src/Bundle/Resources/config/services/field_types.xml
+++ b/src/Bundle/Resources/config/services/field_types.xml
@@ -17,7 +17,7 @@
 
         <service id="Sylius\Component\Grid\FieldTypes\DatetimeFieldType">
             <argument type="service" id="sylius.grid.data_extractor" />
-            <argument>%timezone%</argument>
+            <argument>%sylius_grid.timezone%</argument>
             <tag name="sylius.grid_field" type="datetime" />
         </service>
         <service id="sylius.grid_field.datetime" alias="Sylius\Component\Grid\FieldTypes\DatetimeFieldType" />

--- a/src/Bundle/SyliusGridBundle.php
+++ b/src/Bundle/SyliusGridBundle.php
@@ -17,6 +17,7 @@ use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\RegisterDriversPass;
 use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\RegisterFieldTypesPass;
 use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\RegisterFiltersPass;
 use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\RegisterStubCommandsPass;
+use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\RegisterTimezoneParameterPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -34,6 +35,7 @@ final class SyliusGridBundle extends Bundle
         $container->addCompilerPass(new RegisterFiltersPass());
         $container->addCompilerPass(new RegisterFieldTypesPass());
         $container->addCompilerPass(new RegisterStubCommandsPass());
+        $container->addCompilerPass(new RegisterTimezoneParameterPass());
     }
 
     /**

--- a/src/Bundle/Tests/DependencyInjection/Compiler/RegisterTimezoneParameterPassTest.php
+++ b/src/Bundle/Tests/DependencyInjection/Compiler/RegisterTimezoneParameterPassTest.php
@@ -24,17 +24,17 @@ final class RegisterTimezoneParameterPassTest extends AbstractCompilerPassTestCa
     {
         $this->compile();
 
-        $this->assertContainerBuilderHasParameter('timezone', null);
+        $this->assertContainerBuilderHasParameter('sylius_grid.timezone', null);
     }
 
     /** @test */
     public function it_does_nothing_if_timezone_parameter_already_exists(): void
     {
-        $this->container->setParameter('timezone', 'UTC');
+        $this->container->setParameter('sylius_grid.timezone', 'UTC');
 
         $this->compile();
 
-        $this->assertContainerBuilderHasParameter('timezone', 'UTC');
+        $this->assertContainerBuilderHasParameter('sylius_grid.timezone', 'UTC');
     }
 
     protected function registerCompilerPass(ContainerBuilder $container): void

--- a/src/Bundle/Tests/DependencyInjection/Compiler/RegisterTimezoneParameterPassTest.php
+++ b/src/Bundle/Tests/DependencyInjection/Compiler/RegisterTimezoneParameterPassTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\RegisterTimezoneParameterPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class RegisterTimezoneParameterPassTest extends AbstractCompilerPassTestCase
+{
+    /** @test */
+    public function it_registers_null_timezone_parameter_if_it_does_not_exist(): void
+    {
+        $this->compile();
+
+        $this->assertContainerBuilderHasParameter('timezone', null);
+    }
+
+    /** @test */
+    public function it_does_nothing_if_timezone_parameter_already_exists(): void
+    {
+        $this->container->setParameter('timezone', 'UTC');
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasParameter('timezone', 'UTC');
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new RegisterTimezoneParameterPass());
+    }
+}

--- a/src/Bundle/Tests/DependencyInjection/GridBuilderConfigurationTest.php
+++ b/src/Bundle/Tests/DependencyInjection/GridBuilderConfigurationTest.php
@@ -526,6 +526,7 @@ final class GridBuilderConfigurationTest extends AbstractExtensionTestCase
                         'position' => 100,
                         'options' => [
                             'format' => 'Y-m-d H:i:s',
+                            'timezone' => null,
                         ],
                     ],
                 ],

--- a/src/Component/FieldTypes/DatetimeFieldType.php
+++ b/src/Component/FieldTypes/DatetimeFieldType.php
@@ -37,7 +37,12 @@ final class DatetimeFieldType implements FieldTypeInterface
             return '';
         }
 
+        /** @var \DateTimeImmutable|\DateTime $value */
         Assert::isInstanceOf($value, \DateTimeInterface::class);
+
+        if (null !== $options['timezone']) {
+            $value = $value->setTimezone(new \DateTimeZone($options['timezone']));
+        }
 
         return $value->format($options['format']);
     }
@@ -46,5 +51,7 @@ final class DatetimeFieldType implements FieldTypeInterface
     {
         $resolver->setDefault('format', 'Y-m-d H:i:s');
         $resolver->setAllowedTypes('format', 'string');
+        $resolver->setDefault('timezone', null);
+        $resolver->setAllowedTypes('timezone', ['null', 'string']);
     }
 }

--- a/src/Component/FieldTypes/DatetimeFieldType.php
+++ b/src/Component/FieldTypes/DatetimeFieldType.php
@@ -22,8 +22,10 @@ final class DatetimeFieldType implements FieldTypeInterface
 {
     private DataExtractorInterface $dataExtractor;
 
-    public function __construct(DataExtractorInterface $dataExtractor)
-    {
+    public function __construct(
+        DataExtractorInterface $dataExtractor,
+        private ?string $timezone = null,
+    ) {
         $this->dataExtractor = $dataExtractor;
     }
 
@@ -51,7 +53,7 @@ final class DatetimeFieldType implements FieldTypeInterface
     {
         $resolver->setDefault('format', 'Y-m-d H:i:s');
         $resolver->setAllowedTypes('format', 'string');
-        $resolver->setDefault('timezone', null);
+        $resolver->setDefault('timezone', $this->timezone);
         $resolver->setAllowedTypes('timezone', ['null', 'string']);
     }
 }

--- a/src/Component/composer.json
+++ b/src/Component/composer.json
@@ -35,6 +35,7 @@
         "symfony/deprecation-contracts": "^2.2",
         "symfony/event-dispatcher": "^5.4 || ^6.0",
         "symfony/http-kernel": "^5.4 || ^6.0",
+        "symfony/options-resolver": "^5.4 || ^6.0",
         "webmozart/assert": "^1.9"
     },
     "require-dev": {

--- a/src/Component/spec/FieldTypes/DatetimeFieldTypeSpec.php
+++ b/src/Component/spec/FieldTypes/DatetimeFieldTypeSpec.php
@@ -18,6 +18,7 @@ use Prophecy\Argument;
 use Sylius\Component\Grid\DataExtractor\DataExtractorInterface;
 use Sylius\Component\Grid\Definition\Field;
 use Sylius\Component\Grid\FieldTypes\FieldTypeInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class DatetimeFieldTypeSpec extends ObjectBehavior
 {
@@ -71,6 +72,20 @@ final class DatetimeFieldTypeSpec extends ObjectBehavior
             'format' => '',
             'timezone' => null,
         ])->shouldReturn('');
+    }
+
+    function it_uses_timezone_parameter_as_default_timezone_option(
+        DataExtractorInterface $dataExtractor,
+        OptionsResolver $resolver,
+    ): void {
+        $this->beConstructedWith($dataExtractor, 'Europe/Warsaw');
+
+        $resolver->setDefault('format', 'Y-m-d H:i:s')->willReturn($resolver)->shouldBeCalled();
+        $resolver->setAllowedTypes('format', 'string')->willReturn($resolver)->shouldBeCalled();
+        $resolver->setDefault('timezone', 'Europe/Warsaw')->willReturn($resolver)->shouldBeCalled();
+        $resolver->setAllowedTypes('timezone', ['null', 'string'])->willReturn($resolver)->shouldBeCalled();
+
+        $this->configureOptions($resolver);
     }
 
     function it_throws_exception_if_returned_value_is_not_datetime(DataExtractorInterface $dataExtractor, Field $field): void

--- a/src/Component/spec/FieldTypes/DatetimeFieldTypeSpec.php
+++ b/src/Component/spec/FieldTypes/DatetimeFieldTypeSpec.php
@@ -51,7 +51,7 @@ final class DatetimeFieldTypeSpec extends ObjectBehavior
     function it_sets_timezone_if_specified(
         DataExtractorInterface $dataExtractor,
         \DateTime $dateTime,
-        Field $field
+        Field $field,
     ): void {
         $dataExtractor->get($field, ['foo' => 'bar'])->willReturn($dateTime);
 


### PR DESCRIPTION
It's useful if you'd like to keep all in UTC but expose dates in a specific timezone.
Additionally, it uses `%sylius_grid.timezone%` param as a default timezone for datetime field type.