### PR TITLE
Create action and filter context factories

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,9 +19,10 @@
     </php>
 
     <testsuites>
-        <testsuite name="SyliusGridBundle Test Suite">
+        <testsuite name="Sylius Grid Test Suite">
             <directory>./tests/</directory>
             <directory>./src/Bundle/Tests/</directory>
+            <directory>./src/Component/Tests/</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -15,6 +15,7 @@
     <imports>
         <import resource="services/field_types.xml" />
         <import resource="services/filters.xml" />
+        <import resource="services/renderer_context.xml" />
         <import resource="services/templating.xml" />
         <import resource="services/twig.xml" />
     </imports>
@@ -71,6 +72,8 @@
             <argument type="service" id="sylius.grid.data_provider" />
         </service>
         <service id="sylius.grid.view_factory" alias="Sylius\Component\Grid\View\GridViewFactoryInterface" />
+
+
 
         <service id="sylius.grid.data_provider" class="Sylius\Component\Grid\Data\DataProvider">
             <argument type="service" id="sylius.grid.data_source_provider" />

--- a/src/Bundle/Resources/config/services/renderer_context.xml
+++ b/src/Bundle/Resources/config/services/renderer_context.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Sylius Sp. z o.o.
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <defaults public="false" />
+
+        <service id="sylius.grid.renderer.context.factory.action" class="Sylius\Component\Grid\Renderer\Context\Factory\ActionContextFactory" />
+        <service id="Sylius\Component\Grid\Renderer\Context\Factory\ActionContextFactoryInterface" alias="sylius.grid.renderer.context.factory.action" />
+
+        <service id="sylius.grid.renderer.context.factory.filter" class="Sylius\Component\Grid\Renderer\Context\Factory\FilterContextFactory" />
+        <service id="Sylius\Component\Grid\Renderer\Context\Factory\FilterContextFactoryInterface" alias="sylius.grid.renderer.context.factory.filter" />
+
+    </services>
+</container>

--- a/src/Bundle/Resources/config/services/twig.xml
+++ b/src/Bundle/Resources/config/services/twig.xml
@@ -23,8 +23,11 @@
             <argument>@SyliusGrid/_grid.html.twig</argument>
             <argument>%sylius.grid.templates.action%</argument>
             <argument>%sylius.grid.templates.filter%</argument>
+            <argument type="service" id="sylius.grid.renderer.context.factory.action" />
+            <argument type="service" id="sylius.grid.renderer.context.factory.filter" />
         </service>
         <service id="sylius.grid.renderer.twig" alias="Sylius\Bundle\GridBundle\Renderer\TwigGridRenderer" />
+        <service id="Sylius\Component\Grid\Renderer\GridRendererInterface" alias="Sylius\Bundle\GridBundle\Renderer\TwigGridRenderer" />
 
         <service id="Sylius\Bundle\GridBundle\Renderer\TwigBulkActionGridRenderer">
             <argument type="service" id="twig" />

--- a/src/Component/Renderer/Context/Factory/ActionContextFactory.php
+++ b/src/Component/Renderer/Context/Factory/ActionContextFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Renderer\Context\Factory;
+
+use Sylius\Component\Grid\Definition\Action;
+use Sylius\Component\Grid\View\GridViewInterface;
+
+final class ActionContextFactory implements ActionContextFactoryInterface
+{
+    public function create(GridViewInterface $gridView, Action $action, mixed $data = null): array
+    {
+        return [
+            'grid' => $gridView,
+            'action' => $action,
+            'data' => $data,
+        ];
+    }
+}

--- a/src/Component/Renderer/Context/Factory/ActionContextFactoryInterface.php
+++ b/src/Component/Renderer/Context/Factory/ActionContextFactoryInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Renderer\Context\Factory;
+
+use Sylius\Component\Grid\Definition\Action;
+use Sylius\Component\Grid\View\GridViewInterface;
+
+interface ActionContextFactoryInterface
+{
+    /** @return array<string, mixed> */
+    public function create(GridViewInterface $gridView, Action $action, mixed $data = null): array;
+}

--- a/src/Component/Renderer/Context/Factory/FilterContextFactory.php
+++ b/src/Component/Renderer/Context/Factory/FilterContextFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Renderer\Context\Factory;
+
+use Sylius\Component\Grid\Definition\Filter;
+use Sylius\Component\Grid\View\GridViewInterface;
+
+final class FilterContextFactory implements FilterContextFactoryInterface
+{
+    public function create(GridViewInterface $gridView, Filter $filter): array
+    {
+        return [
+            'grid' => $gridView,
+            'filter' => $filter,
+        ];
+    }
+}

--- a/src/Component/Renderer/Context/Factory/FilterContextFactoryInterface.php
+++ b/src/Component/Renderer/Context/Factory/FilterContextFactoryInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Renderer\Context\Factory;
+
+use Sylius\Component\Grid\Definition\Filter;
+use Sylius\Component\Grid\View\GridViewInterface;
+
+interface FilterContextFactoryInterface
+{
+    /** @return array<string, mixed> */
+    public function create(GridViewInterface $gridView, Filter $filter): array;
+}

--- a/src/Component/Tests/Functional/Renderer/Context/Factory/ActionContextFactoryTest.php
+++ b/src/Component/Tests/Functional/Renderer/Context/Factory/ActionContextFactoryTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Tests\Functional\Renderer\Context\Factory;
+
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Grid\Definition\Action;
+use Sylius\Component\Grid\Definition\Grid;
+use Sylius\Component\Grid\Parameters;
+use Sylius\Component\Grid\Renderer\Context\Factory\ActionContextFactory;
+use Sylius\Component\Grid\View\GridView;
+
+final class ActionContextFactoryTest extends TestCase
+{
+    public function testItBuildAContextFactory(): void
+    {
+        $data = ['foo' => 'fighters'];
+        $gridView = new GridView(
+            $data,
+            Grid::fromCodeAndDriverConfiguration('app_book', 'doctrine/orm', []),
+            new Parameters(),
+        );
+        $action = Action::fromNameAndType('delete', 'delete');
+
+        $contextFactory = new ActionContextFactory();
+
+        $this->assertEquals([
+            'grid' => $gridView,
+            'action' => $action,
+            'data' => $data,
+        ], $contextFactory->create($gridView, $action, $data));
+    }
+}

--- a/src/Component/Tests/Functional/Renderer/Context/Factory/FilterContextFactoryTest.php
+++ b/src/Component/Tests/Functional/Renderer/Context/Factory/FilterContextFactoryTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Tests\Functional\Renderer\Context\Factory;
+
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Grid\Definition\Filter;
+use Sylius\Component\Grid\Definition\Grid;
+use Sylius\Component\Grid\Parameters;
+use Sylius\Component\Grid\Renderer\Context\Factory\FilterContextFactory;
+use Sylius\Component\Grid\View\GridView;
+
+final class FilterContextFactoryTest extends TestCase
+{
+    public function testItBuildAContextFactory(): void
+    {
+        $data = ['foo' => 'fighters'];
+        $gridView = new GridView(
+            $data,
+            Grid::fromCodeAndDriverConfiguration('app_book', 'doctrine/orm', []),
+            new Parameters(),
+        );
+        $filter = Filter::fromNameAndType('search', 'string');
+
+        $contextFactory = new FilterContextFactory();
+
+        $this->assertEquals([
+            'grid' => $gridView,
+            'filter' => $filter,
+        ], $contextFactory->create($gridView, $filter));
+    }
+}


### PR DESCRIPTION
In Sylius resource bundle, a Twig Grid renderer decorates the grid one in order to add some data to the context (Twig context here but the renderer does not depends on Twig).

Cause I need to add things on resource side to this context, I think it will be easier to allow decorating that context instead.

Example for the future in Resource package to improve that https://github.com/Sylius/SyliusResourceBundle/blob/1.11/src/Bundle/Grid/Renderer/TwigGridRenderer.php#L64

```
final class ActionContextFactory implemented ActionContextFactoryInterface
{
    public function __construct(
        private ActionContextFactoryInterface $contextFactory,
        private OptionsParserInterface $optionsParser,
    ) {
    }

    public function create(GridViewInterface $gridView, Action $action, mixed $data = null): array
    {
        $options = $this->optionsParser->parseOptions(
            $action->getOptions(),
            $gridView->getRequestConfiguration()->getRequest(),
            $data,
        );

        return array_merge($this->contextFactory->create($grid, $action, $data), [
            'grid' => $gridView,
            'action' => $action,
            'data' => $data,
            'options' => $options,
        ]);
    }
}
```

Cause I will also need to add new context data when using the new routing system.