### PR TITLE
Update RegisterFiltersPass.php

### DIFF
--- a/src/Bundle/DependencyInjection/Compiler/RegisterFiltersPass.php
+++ b/src/Bundle/DependencyInjection/Compiler/RegisterFiltersPass.php
@@ -35,12 +35,15 @@ final class RegisterFiltersPass implements CompilerPassInterface
             $type = null;
             $formType = null;
 
-            if (is_a($id, TypeAwareFilterInterface::class, true)) {
-                $type = $id::getType();
+            $definition = $container->getDefinition($id);
+            $class = $definition->getClass();
+
+            if (is_a($class, TypeAwareFilterInterface::class, true)) {
+                $type = $class::getType();
             }
 
-            if (is_a($id, FormTypeAwareFilterInterface::class, true)) {
-                $formType = $id::getFormType();
+            if (is_a($class, FormTypeAwareFilterInterface::class, true)) {
+                $formType = $class::getFormType();
             }
 
             foreach ($attributes as $attribute) {


### PR DESCRIPTION
In v1.13 filters which has implemented ```FilterInterface``` are autoregistered, but for this case:

```yaml
    sylius.grid_filter.enum:
        class: App\Component\Grid\Filter\EnumFilter
```

in compiler pass will be empty attribute from $container->registerForAutoconfiguration(FilterInterface::class) and exception is thrown on line #48 even the class has impletemented all methods from ConfigurableFilterInterface. In case when service ID is not an FQCN we should get service class.

