### PR TITLE
[Fix] Flip (back) service ids and aliases

### DIFF
--- a/src/Bundle/DependencyInjection/Compiler/RegisterStubCommandsPass.php
+++ b/src/Bundle/DependencyInjection/Compiler/RegisterStubCommandsPass.php
@@ -28,8 +28,8 @@ final class RegisterStubCommandsPass implements CompilerPassInterface
     {
         if (!$this->isMakerEnabled($container)) {
             $container->register(StubMakeGrid::class)->setClass(StubMakeGrid::class)->addTag('console.command');
-            $container->removeDefinition(MakeGrid::class);
-            $container->removeAlias('sylius.grid.maker');
+            $container->removeDefinition('sylius.grid.maker');
+            $container->removeAlias(MakeGrid::class);
         }
     }
 

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -22,55 +22,55 @@
     <services>
         <defaults public="true" />
 
-        <service id="Sylius\Component\Grid\DataExtractor\PropertyAccessDataExtractor">
+        <service id="sylius.grid.data_extractor.property_access" class="Sylius\Component\Grid\DataExtractor\PropertyAccessDataExtractor">
             <argument type="service" id="property_accessor" />
         </service>
-        <service id="sylius.grid.data_extractor.property_access" alias="Sylius\Component\Grid\DataExtractor\PropertyAccessDataExtractor" />
+        <service id="Sylius\Component\Grid\DataExtractor\PropertyAccessDataExtractor" alias="sylius.grid.data_extractor.property_access" />
 
-        <service id="Sylius\Component\Grid\Definition\ArrayToDefinitionConverterInterface" class="Sylius\Component\Grid\Definition\ArrayToDefinitionConverter">
+        <service id="sylius.grid.array_to_definition_converter" class="Sylius\Component\Grid\Definition\ArrayToDefinitionConverter">
             <argument type="service" id="event_dispatcher" />
         </service>
-        <service id="sylius.grid.array_to_definition_converter" alias="Sylius\Component\Grid\Definition\ArrayToDefinitionConverterInterface" />
+        <service id="Sylius\Component\Grid\Definition\ArrayToDefinitionConverterInterface" alias="sylius.grid.array_to_definition_converter" />
 
         <service id="sylius.grid.grid_registry" class="Sylius\Bundle\GridBundle\Registry\GridRegistry">
             <argument type="tagged_locator" tag="sylius.grid" index-by="name" default-index-method="getName"/>
         </service>
         <service id="Sylius\Bundle\GridBundle\Registry\GridRegistryInterface" alias="sylius.grid.grid_registry" />
 
-        <service id="Sylius\Component\Grid\Configuration\GridConfigurationExtenderInterface" class="Sylius\Component\Grid\Configuration\GridConfigurationExtender"/>
-        <service id="sylius.grid.configuration_extender" alias="Sylius\Component\Grid\Configuration\GridConfigurationExtenderInterface" />
+        <service id="sylius.grid.configuration_extender" class="Sylius\Component\Grid\Configuration\GridConfigurationExtender"/>
+        <service id="Sylius\Component\Grid\Configuration\GridConfigurationExtenderInterface" alias="sylius.grid.configuration_extender" />
 
         <service id="sylius.grid.configuration_removals_handler" class="Sylius\Component\Grid\Configuration\GridConfigurationRemovalsHandler"/>
         <service id="Sylius\Component\Grid\Configuration\GridConfigurationRemovalsHandlerInterface" alias="sylius.grid.configuration_removals_handler" />
 
-        <service id="Sylius\Component\Grid\Provider\ArrayGridProvider">
+        <service id="sylius.grid.array_grid_provider" class="Sylius\Component\Grid\Provider\ArrayGridProvider">
             <argument type="service" id="sylius.grid.array_to_definition_converter" />
             <argument>%sylius.grids_definitions%</argument>
             <argument type="service" id="sylius.grid.configuration_extender" />
             <argument type="service" id="sylius.grid.configuration_removals_handler" />
             <tag name="sylius.grid_provider" key="array" priority="-200"/>
         </service>
-        <service id="sylius.grid.array_grid_provider" alias="Sylius\Component\Grid\Provider\ArrayGridProvider" />
+        <service id="Sylius\Component\Grid\Provider\ArrayGridProvider" alias="sylius.grid.array_grid_provider" />
 
-        <service id="Sylius\Bundle\GridBundle\Provider\ServiceGridProvider">
+        <service id="sylius.grid.service_grid_provider" class="Sylius\Bundle\GridBundle\Provider\ServiceGridProvider">
             <argument type="service" id="sylius.grid.array_to_definition_converter" />
             <argument type="service" id="sylius.grid.grid_registry" />
             <argument type="service" id="sylius.grid.configuration_extender" />
             <argument type="service" id="sylius.grid.configuration_removals_handler" />
             <tag name="sylius.grid_provider" key="service" priority="-100"/>
         </service>
-        <service id="sylius.grid.service_grid_provider" alias="Sylius\Bundle\GridBundle\Provider\ServiceGridProvider" />
+        <service id="Sylius\Bundle\GridBundle\Provider\ServiceGridProvider" alias="sylius.grid.service_grid_provider" />
 
-        <service id="Sylius\Component\Grid\Provider\ChainProvider">
+        <service id="sylius.grid.chain_provider" class="Sylius\Component\Grid\Provider\ChainProvider">
             <argument type="tagged_iterator" tag="sylius.grid_provider" />
         </service>
-        <service id="sylius.grid.chain_provider" alias="Sylius\Component\Grid\Provider\ChainProvider"/>
-        <service id="sylius.grid.provider" alias="Sylius\Component\Grid\Provider\ChainProvider"/>
+        <service id="Sylius\Component\Grid\Provider\ChainProvider" alias="sylius.grid.chain_provider"/>
+        <service id="sylius.grid.provider" alias="sylius.grid.chain_provider"/>
 
-        <service id="Sylius\Component\Grid\View\GridViewFactoryInterface" class="Sylius\Component\Grid\View\GridViewFactory">
+        <service id="sylius.grid.view_factory" class="Sylius\Component\Grid\View\GridViewFactory">
             <argument type="service" id="sylius.grid.data_provider" />
         </service>
-        <service id="sylius.grid.view_factory" alias="Sylius\Component\Grid\View\GridViewFactoryInterface" />
+        <service id="Sylius\Component\Grid\View\GridViewFactoryInterface" alias="sylius.grid.view_factory" />
 
         <service id="sylius.grid.data_provider" class="Sylius\Component\Grid\Data\DataProvider">
             <argument type="service" id="sylius.grid.data_source_provider" />
@@ -84,26 +84,26 @@
             <argument type="service" id=".inner" />
         </service>
 
-        <service id="Sylius\Component\Grid\Filtering\FiltersCriteriaResolverInterface" class="Sylius\Component\Grid\Filtering\FiltersCriteriaResolver" />
-        <service id="sylius.grid.filters_criteria_resolver" alias="Sylius\Component\Grid\Filtering\FiltersCriteriaResolverInterface" />
+        <service id="sylius.grid.filters_criteria_resolver" class="Sylius\Component\Grid\Filtering\FiltersCriteriaResolver" />
+        <service id="Sylius\Component\Grid\Filtering\FiltersCriteriaResolverInterface" alias="sylius.grid.filters_criteria_resolver" />
 
-        <service id="Sylius\Component\Grid\Filtering\FiltersApplicatorInterface" class="Sylius\Component\Grid\Filtering\FiltersApplicator">
+        <service id="sylius.grid.filters_applicator" class="Sylius\Component\Grid\Filtering\FiltersApplicator">
             <argument type="service" id="sylius.registry.grid_filter" />
             <argument type="service" id="sylius.grid.filters_criteria_resolver" />
         </service>
-        <service id="sylius.grid.filters_applicator" alias="Sylius\Component\Grid\Filtering\FiltersApplicatorInterface" />
+        <service id="Sylius\Component\Grid\Filtering\FiltersApplicatorInterface" alias="sylius.grid.filters_applicator" />
 
         <service id="sylius.grid.sorter.validator" class="Sylius\Component\Grid\Validation\SortingParametersValidator" />
         <service id="Sylius\Component\Grid\Validation\SortingParametersValidatorInterface" alias="sylius.grid.sorter.validator" />
 
-        <service id="Sylius\Component\Grid\Validation\FieldValidatorInterface" class="Sylius\Component\Grid\Validation\FieldValidator" />
-        <service id="sylius.grid.field.validator" alias="Sylius\Component\Grid\Validation\FieldValidatorInterface" />
+        <service id="sylius.grid.field.validator" class="Sylius\Component\Grid\Validation\FieldValidator" />
+        <service id="Sylius\Component\Grid\Validation\FieldValidatorInterface" alias="sylius.grid.field.validator" />
 
-        <service id="Sylius\Component\Grid\Sorting\SorterInterface" class="Sylius\Component\Grid\Sorting\Sorter">
+        <service id="sylius.grid.sorter" class="Sylius\Component\Grid\Sorting\Sorter">
             <argument type="service" id="sylius.grid.sorter.validator" />
             <argument type="service" id="sylius.grid.field.validator" />
         </service>
-        <service id="sylius.grid.sorter" alias="Sylius\Component\Grid\Sorting\SorterInterface" />
+        <service id="Sylius\Component\Grid\Sorting\SorterInterface" alias="sylius.grid.sorter" />
 
         <service id="Sylius\Component\Grid\Data\DataSourceProviderInterface" class="Sylius\Component\Grid\Data\DataSourceProvider">
             <argument type="service" id="sylius.registry.grid_driver" />
@@ -123,10 +123,10 @@
             <argument>grid field</argument>
         </service>
 
-        <service id="Sylius\Bundle\GridBundle\Maker\MakeGrid">
+        <service id="sylius.grid.maker" class="Sylius\Bundle\GridBundle\Maker\MakeGrid">
             <argument type="service" id="doctrine" />
             <tag name="maker.command" />
         </service>
-        <service id="sylius.grid.maker" alias="Sylius\Bundle\GridBundle\Maker\MakeGrid" />
+        <service id="Sylius\Bundle\GridBundle\Maker\MakeGrid" alias="sylius.grid.maker" />
     </services>
 </container>

--- a/src/Bundle/Resources/config/services/field_types.xml
+++ b/src/Bundle/Resources/config/services/field_types.xml
@@ -15,24 +15,24 @@
     <services>
         <defaults public="true" />
 
-        <service id="Sylius\Component\Grid\FieldTypes\DatetimeFieldType">
+        <service id="sylius.grid_field.datetime" class="Sylius\Component\Grid\FieldTypes\DatetimeFieldType">
             <argument type="service" id="sylius.grid.data_extractor" />
             <argument>%sylius_grid.timezone%</argument>
             <tag name="sylius.grid_field" type="datetime" />
         </service>
-        <service id="sylius.grid_field.datetime" alias="Sylius\Component\Grid\FieldTypes\DatetimeFieldType" />
+        <service id="Sylius\Component\Grid\FieldTypes\DatetimeFieldType" alias="sylius.grid_field.datetime" />
 
-        <service id="Sylius\Component\Grid\FieldTypes\StringFieldType">
+        <service id="sylius.grid_field.string" class="Sylius\Component\Grid\FieldTypes\StringFieldType">
             <argument type="service" id="sylius.grid.data_extractor" />
             <tag name="sylius.grid_field" type="string" />
         </service>
-        <service id="sylius.grid_field.string" alias="Sylius\Component\Grid\FieldTypes\StringFieldType" />
+        <service id="Sylius\Component\Grid\FieldTypes\StringFieldType" alias="sylius.grid_field.string" />
 
-        <service id="Sylius\Bundle\GridBundle\FieldTypes\TwigFieldType">
+        <service id="sylius.grid_field.twig" class="Sylius\Bundle\GridBundle\FieldTypes\TwigFieldType">
             <argument type="service" id="sylius.grid.data_extractor" />
             <argument type="service" id="twig" />
             <tag name="sylius.grid_field" type="twig" />
         </service>
-        <service id="sylius.grid_field.twig" alias="Sylius\Bundle\GridBundle\FieldTypes\TwigFieldType" />
+        <service id="Sylius\Bundle\GridBundle\FieldTypes\TwigFieldType" alias="sylius.grid_field.twig" />
     </services>
 </container>

--- a/src/Bundle/Resources/config/services/filters.xml
+++ b/src/Bundle/Resources/config/services/filters.xml
@@ -23,74 +23,74 @@
 
         <service id="sylius.form_registry.grid_filter" class="Sylius\Bundle\GridBundle\Form\Registry\FormTypeRegistry" public="false" />
 
-        <service id="Sylius\Component\Grid\Filter\StringFilter">
+        <service id="sylius.grid_filter.string" class="Sylius\Component\Grid\Filter\StringFilter">
             <tag name="sylius.grid_filter" type="string" form-type="Sylius\Bundle\GridBundle\Form\Type\Filter\StringFilterType" />
         </service>
-        <service id="sylius.grid_filter.string" alias="Sylius\Component\Grid\Filter\StringFilter" />
+        <service id="Sylius\Component\Grid\Filter\StringFilter" alias="sylius.grid_filter.string" />
 
         <service id="Sylius\Bundle\GridBundle\Form\Type\Filter\StringFilterType">
             <tag name="form.type" />
         </service>
         <service id="sylius.form.type.grid_filter.string" alias="Sylius\Bundle\GridBundle\Form\Type\Filter\StringFilterType" />
 
-        <service id="Sylius\Component\Grid\Filter\BooleanFilter">
+        <service id="sylius.grid_filter.boolean" class="Sylius\Component\Grid\Filter\BooleanFilter">
             <tag name="sylius.grid_filter" type="boolean" form-type="Sylius\Bundle\GridBundle\Form\Type\Filter\BooleanFilterType" />
         </service>
-        <service id="sylius.grid_filter.boolean" alias="Sylius\Component\Grid\Filter\BooleanFilter" />
+        <service id="Sylius\Component\Grid\Filter\BooleanFilter" alias="sylius.grid_filter.boolean" />
 
-        <service id="Sylius\Bundle\GridBundle\Form\Type\Filter\BooleanFilterType">
+        <service id="sylius.form.type.grid_filter.boolean" class="Sylius\Bundle\GridBundle\Form\Type\Filter\BooleanFilterType">
             <tag name="form.type" />
         </service>
-        <service id="sylius.form.type.grid_filter.boolean" alias="Sylius\Bundle\GridBundle\Form\Type\Filter\BooleanFilterType" />
+        <service id="Sylius\Bundle\GridBundle\Form\Type\Filter\BooleanFilterType" alias="sylius.form.type.grid_filter.boolean" />
 
-        <service id="Sylius\Component\Grid\Filter\DateFilter">
+        <service id="sylius.grid_filter.date" class="Sylius\Component\Grid\Filter\DateFilter">
             <tag name="sylius.grid_filter" type="date" form-type="Sylius\Bundle\GridBundle\Form\Type\Filter\DateFilterType" />
         </service>
-        <service id="sylius.grid_filter.date" alias="Sylius\Component\Grid\Filter\DateFilter" />
+        <service id="Sylius\Component\Grid\Filter\DateFilter" alias="sylius.grid_filter.date" />
 
-        <service id="Sylius\Bundle\GridBundle\Form\Type\Filter\DateFilterType">
+        <service id="sylius.form.type.grid_filter.date" class="Sylius\Bundle\GridBundle\Form\Type\Filter\DateFilterType">
             <tag name="form.type" />
         </service>
-        <service id="sylius.form.type.grid_filter.date" alias="Sylius\Bundle\GridBundle\Form\Type\Filter\DateFilterType" />
+        <service id="Sylius\Bundle\GridBundle\Form\Type\Filter\DateFilterType" alias="sylius.form.type.grid_filter.date" />
 
-        <service id="Sylius\Component\Grid\Filter\EntityFilter">
+        <service id="sylius.grid_filter.entity" class="Sylius\Component\Grid\Filter\EntityFilter">
             <tag name="sylius.grid_filter" type="entity" form-type="Sylius\Bundle\GridBundle\Form\Type\Filter\EntityFilterType" />
         </service>
-        <service id="sylius.grid_filter.entity" alias="Sylius\Component\Grid\Filter\EntityFilter" />
+        <service id="Sylius\Component\Grid\Filter\EntityFilter" alias="sylius.grid_filter.entity" />
 
-        <service id="Sylius\Bundle\GridBundle\Form\Type\Filter\EntityFilterType">
+        <service id="sylius.form.type.grid_filter.entity" class="Sylius\Bundle\GridBundle\Form\Type\Filter\EntityFilterType">
             <tag name="form.type" />
         </service>
-        <service id="sylius.form.type.grid_filter.entity" alias="Sylius\Bundle\GridBundle\Form\Type\Filter\EntityFilterType" />
+        <service id="Sylius\Bundle\GridBundle\Form\Type\Filter\EntityFilterType" alias="sylius.form.type.grid_filter.entity" />
 
-        <service id="Sylius\Component\Grid\Filter\ExistsFilter">
+        <service id="sylius.grid_filter.exists" class="Sylius\Component\Grid\Filter\ExistsFilter">
             <tag name="sylius.grid_filter" type="exists" form-type="Sylius\Bundle\GridBundle\Form\Type\Filter\ExistsFilterType" />
         </service>
-        <service id="sylius.grid_filter.exists" alias="Sylius\Component\Grid\Filter\ExistsFilter" />
+        <service id="Sylius\Component\Grid\Filter\ExistsFilter" alias="sylius.grid_filter.exists" />
 
-        <service id="Sylius\Bundle\GridBundle\Form\Type\Filter\ExistsFilterType">
+        <service id="sylius.form.type.grid_filter.exists" class="Sylius\Bundle\GridBundle\Form\Type\Filter\ExistsFilterType">
             <tag name="form.type" />
         </service>
-        <service id="sylius.form.type.grid_filter.exists" alias="Sylius\Bundle\GridBundle\Form\Type\Filter\ExistsFilterType" />
+        <service id="Sylius\Bundle\GridBundle\Form\Type\Filter\ExistsFilterType" alias="sylius.form.type.grid_filter.exists" />
 
         <service id="Sylius\Component\Grid\Filter\NumericRangeFilter">
             <tag name="sylius.grid_filter" type="numeric_range" form-type="Sylius\Bundle\GridBundle\Form\Type\Filter\NumericRangeFilterType" />
         </service>
         <service id="sylius.grid_filter.numeric_range" alias="Sylius\Component\Grid\Filter\NumericRangeFilter" />
 
-        <service id="Sylius\Bundle\GridBundle\Form\Type\Filter\NumericRangeFilterType">
+        <service id="sylius.form.type.grid_filter.numeric_range" class="Sylius\Bundle\GridBundle\Form\Type\Filter\NumericRangeFilterType">
             <tag name="form.type" />
         </service>
-        <service id="sylius.form.type.grid_filter.numeric_range" alias="Sylius\Bundle\GridBundle\Form\Type\Filter\NumericRangeFilterType" />
+        <service id="Sylius\Bundle\GridBundle\Form\Type\Filter\NumericRangeFilterType" alias="sylius.form.type.grid_filter.numeric_range" />
 
-        <service id="Sylius\Component\Grid\Filter\SelectFilter">
+        <service id="sylius.grid_filter.select" class="Sylius\Component\Grid\Filter\SelectFilter">
             <tag name="sylius.grid_filter" type="select" form-type="Sylius\Bundle\GridBundle\Form\Type\Filter\SelectFilterType" />
         </service>
-        <service id="sylius.grid_filter.select" alias="Sylius\Component\Grid\Filter\SelectFilter" />
+        <service id="Sylius\Component\Grid\Filter\SelectFilter" alias="sylius.grid_filter.select" />
 
-        <service id="Sylius\Bundle\GridBundle\Form\Type\Filter\SelectFilterType">
+        <service id="sylius.form.type.grid_filter.select" class="Sylius\Bundle\GridBundle\Form\Type\Filter\SelectFilterType">
             <tag name="form.type" />
         </service>
-        <service id="sylius.form.type.grid_filter.select" alias="Sylius\Bundle\GridBundle\Form\Type\Filter\SelectFilterType" />
+        <service id="Sylius\Bundle\GridBundle\Form\Type\Filter\SelectFilterType" alias="sylius.form.type.grid_filter.select" />
     </services>
 </container>

--- a/src/Bundle/Resources/config/services/integrations/doctrine/orm.xml
+++ b/src/Bundle/Resources/config/services/integrations/doctrine/orm.xml
@@ -15,16 +15,16 @@
     <services>
         <defaults public="true" />
 
-        <service id="Sylius\Bundle\GridBundle\Doctrine\ORM\Driver">
+        <service id="sylius.grid_driver.doctrine.orm" class="Sylius\Bundle\GridBundle\Doctrine\ORM\Driver">
             <argument type="service" id="doctrine" />
             <tag name="sylius.grid_driver" alias="doctrine/orm" />
         </service>
-        <service id="sylius.grid_driver.doctrine.orm" alias="Sylius\Bundle\GridBundle\Doctrine\ORM\Driver" />
+        <service id="Sylius\Bundle\GridBundle\Doctrine\ORM\Driver" alias="sylius.grid_driver.doctrine.orm" />
 
-        <service id="Sylius\Bundle\GridBundle\Doctrine\DBAL\Driver">
+        <service id="sylius.grid_driver.doctrine.dbal" class="Sylius\Bundle\GridBundle\Doctrine\DBAL\Driver">
             <argument type="service" id="doctrine.dbal.default_connection" />
             <tag name="sylius.grid_driver" alias="doctrine/dbal" />
         </service>
-        <service id="sylius.grid_driver.doctrine.dbal" alias="Sylius\Bundle\GridBundle\Doctrine\DBAL\Driver" />
+        <service id="Sylius\Bundle\GridBundle\Doctrine\DBAL\Driver" alias="sylius.grid_driver.doctrine.dbal" />
     </services>
 </container>

--- a/src/Bundle/Resources/config/services/integrations/sylius_currency_bundle.xml
+++ b/src/Bundle/Resources/config/services/integrations/sylius_currency_bundle.xml
@@ -15,14 +15,14 @@
     <services>
         <defaults public="true" />
 
-        <service id="Sylius\Component\Grid\Filter\MoneyFilter">
+        <service id="sylius.grid_filter.money" class="Sylius\Component\Grid\Filter\MoneyFilter">
             <tag name="sylius.grid_filter" type="money" form-type="Sylius\Bundle\GridBundle\Form\Type\Filter\MoneyFilterType" />
         </service>
-        <service id="sylius.grid_filter.money" alias="Sylius\Component\Grid\Filter\MoneyFilter" />
+        <service id="Sylius\Component\Grid\Filter\MoneyFilter" alias="sylius.grid_filter.money" />
 
-        <service id="Sylius\Bundle\GridBundle\Form\Type\Filter\MoneyFilterType">
+        <service id="sylius.form.type.grid_filter.money" class="Sylius\Bundle\GridBundle\Form\Type\Filter\MoneyFilterType">
             <tag name="form.type" />
         </service>
-        <service id="sylius.form.type.grid_filter.money" alias="Sylius\Bundle\GridBundle\Form\Type\Filter\MoneyFilterType" />
+        <service id="Sylius\Bundle\GridBundle\Form\Type\Filter\MoneyFilterType" alias="sylius.form.type.grid_filter.money" />
     </services>
 </container>

--- a/src/Bundle/Resources/config/services/templating.xml
+++ b/src/Bundle/Resources/config/services/templating.xml
@@ -15,14 +15,14 @@
     <services>
         <defaults public="true" />
 
-        <service id="Sylius\Bundle\GridBundle\Templating\Helper\GridHelper" lazy="true">
+        <service id="sylius.templating.helper.grid" class="Sylius\Bundle\GridBundle\Templating\Helper\GridHelper" lazy="true">
             <argument type="service" id="sylius.grid.renderer" />
         </service>
-        <service id="sylius.templating.helper.grid" alias="Sylius\Bundle\GridBundle\Templating\Helper\GridHelper" />
+        <service id="Sylius\Bundle\GridBundle\Templating\Helper\GridHelper" alias="sylius.templating.helper.grid" />
 
-        <service id="Sylius\Bundle\GridBundle\Templating\Helper\BulkActionGridHelper" lazy="true">
+        <service id="sylius.templating.helper.bulk_action_grid" class="Sylius\Bundle\GridBundle\Templating\Helper\BulkActionGridHelper" lazy="true">
             <argument type="service" id="sylius.grid.bulk_action_renderer" />
         </service>
-        <service id="sylius.templating.helper.bulk_action_grid" alias="Sylius\Bundle\GridBundle\Templating\Helper\BulkActionGridHelper" />
+        <service id="Sylius\Bundle\GridBundle\Templating\Helper\BulkActionGridHelper" alias="sylius.templating.helper.bulk_action_grid" />
     </services>
 </container>

--- a/src/Bundle/Resources/config/services/twig.xml
+++ b/src/Bundle/Resources/config/services/twig.xml
@@ -15,7 +15,7 @@
     <services>
         <defaults public="true" />
 
-        <service id="Sylius\Bundle\GridBundle\Renderer\TwigGridRenderer">
+        <service id="sylius.grid.renderer.twig" class="Sylius\Bundle\GridBundle\Renderer\TwigGridRenderer">
             <argument type="service" id="twig" />
             <argument type="service" id="sylius.registry.grid_field" />
             <argument type="service" id="form.factory" />
@@ -24,24 +24,24 @@
             <argument>%sylius.grid.templates.action%</argument>
             <argument>%sylius.grid.templates.filter%</argument>
         </service>
-        <service id="sylius.grid.renderer.twig" alias="Sylius\Bundle\GridBundle\Renderer\TwigGridRenderer" />
+        <service id="Sylius\Bundle\GridBundle\Renderer\TwigGridRenderer" alias="sylius.grid.renderer.twig" />
 
-        <service id="Sylius\Bundle\GridBundle\Renderer\TwigBulkActionGridRenderer">
+        <service id="sylius.grid.bulk_action_renderer.twig" class="Sylius\Bundle\GridBundle\Renderer\TwigBulkActionGridRenderer">
             <argument type="service" id="twig" />
             <argument>%sylius.grid.templates.bulk_action%</argument>
         </service>
-        <service id="sylius.grid.bulk_action_renderer.twig" alias="Sylius\Bundle\GridBundle\Renderer\TwigBulkActionGridRenderer" />
+        <service id="Sylius\Bundle\GridBundle\Renderer\TwigBulkActionGridRenderer" alias="sylius.grid.bulk_action_renderer.twig" />
 
-        <service id="Sylius\Bundle\GridBundle\Twig\GridExtension" public="false">
+        <service id="sylius.twig.extension.grid" class="Sylius\Bundle\GridBundle\Twig\GridExtension" public="false">
             <argument type="service" id="sylius.templating.helper.grid" />
             <tag name="twig.extension" />
         </service>
-        <service id="sylius.twig.extension.grid" alias="Sylius\Bundle\GridBundle\Twig\GridExtension" public="false" />
+        <service id="Sylius\Bundle\GridBundle\Twig\GridExtension" alias="sylius.twig.extension.grid" public="false" />
 
-        <service id="Sylius\Bundle\GridBundle\Twig\BulkActionGridExtension" public="false">
+        <service id="sylius.twig.extension.bulk_action_grid" class="Sylius\Bundle\GridBundle\Twig\BulkActionGridExtension" public="false">
             <argument type="service" id="sylius.templating.helper.bulk_action_grid" />
             <tag name="twig.extension" />
         </service>
-        <service id="sylius.twig.extension.bulk_action_grid" alias="Sylius\Bundle\GridBundle\Twig\BulkActionGridExtension" public="false" />
+        <service id="Sylius\Bundle\GridBundle\Twig\BulkActionGridExtension" alias="sylius.twig.extension.bulk_action_grid" public="false" />
     </services>
 </container>

--- a/src/Bundle/Tests/DependencyInjection/Compiler/RegisterStubCommandsPassTest.php
+++ b/src/Bundle/Tests/DependencyInjection/Compiler/RegisterStubCommandsPassTest.php
@@ -43,22 +43,22 @@ final class RegisterStubCommandsPassTest extends AbstractCompilerPassTestCase
     /** @test */
     public function it_unregisters_definition_for_grid_maker_when_maker_is_not_registered(): void
     {
-        $this->registerService(MakeGrid::class, MakeGrid::class);
+        $this->registerService('sylius.grid.maker', MakeGrid::class);
 
         $this->compile();
 
-        $this->assertContainerBuilderNotHasService(MakeGrid::class);
+        $this->assertContainerBuilderNotHasService('sylius.grid.maker');
     }
 
     /** @test */
     public function it_does_not_unregister_definition_for_grid_maker_when_maker_is_registered(): void
     {
         $this->setParameter('kernel.bundles', [MakerBundle::class]);
-        $this->registerService(MakeGrid::class, MakeGrid::class);
+        $this->registerService('sylius.grid.maker', MakeGrid::class);
 
         $this->compile();
 
-        $this->assertContainerBuilderHasService(MakeGrid::class, MakeGrid::class);
+        $this->assertContainerBuilderHasService('sylius.grid.maker', MakeGrid::class);
     }
 
     protected function registerCompilerPass(ContainerBuilder $container): void


### PR DESCRIPTION
Unfortunately, service decoration doesn't work with alias.
We reverted these changes on Resource and forgot to do the same on Grid package.