### PR TITLE
Introduce AsFilter attribute to define filter type and form type

### DIFF
--- a/src/Bundle/DependencyInjection/Compiler/RegisterFiltersPass.php
+++ b/src/Bundle/DependencyInjection/Compiler/RegisterFiltersPass.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\GridBundle\DependencyInjection\Compiler;
 
-use InvalidArgumentException;
 use Sylius\Component\Grid\Attribute\AsFilter;
 use Sylius\Component\Grid\Filtering\FormTypeAwareFilterInterface;
 use Sylius\Component\Grid\Filtering\TypeAwareFilterInterface;
@@ -30,11 +29,11 @@ final class RegisterFiltersPass implements CompilerPassInterface
             return;
         }
 
-        $filterRegistry = $container->getDefinition('sylius.registry.grid_filter');
+        $registry = $container->getDefinition('sylius.registry.grid_filter');
         $formTypeRegistry = $container->getDefinition('sylius.form_registry.grid_filter');
 
         foreach ($container->findTaggedServiceIds(AsFilter::SERVICE_TAG) as $id => $attributes) {
-            $this->registerFilter($filterRegistry, $formTypeRegistry, $id, $attributes);
+            $this->registerFilter($registry, $formTypeRegistry, $id, $attributes);
         }
 
         foreach ($container->findTaggedServiceIds('sylius.legacy_grid_filter') as $id => $attributes) {
@@ -59,7 +58,7 @@ final class RegisterFiltersPass implements CompilerPassInterface
                 $formType = $class::getFormType();
             }
 
-            $this->registerFilter($filterRegistry, $formTypeRegistry, $id, $attributes, $type, $formType);
+            $this->registerFilter($registry, $formTypeRegistry, $id, $attributes, $type, $formType);
         }
     }
 
@@ -73,11 +72,11 @@ final class RegisterFiltersPass implements CompilerPassInterface
     ): void {
         foreach ($attributes as $attribute) {
             if (null === $type && null === ($attribute['type'] ?? null)) {
-                throw new InvalidArgumentException(sprintf('Tagged grid filters needs to have "type" attribute or implements "%s".', TypeAwareFilterInterface::class));
+                throw new \InvalidArgumentException(sprintf('Tagged grid filters needs to have "type" attribute or implements "%s".', TypeAwareFilterInterface::class));
             }
 
             if (null === $formType && null === ($attribute['form_type'] ?? null)) {
-                throw new InvalidArgumentException(sprintf('Tagged grid filters needs to have "form_type" attribute or implements "%s".', FormTypeAwareFilterInterface::class));
+                throw new \InvalidArgumentException(sprintf('Tagged grid filters needs to have "form_type" attribute or implements "%s".', FormTypeAwareFilterInterface::class));
             }
 
             $filterRegistry->addMethodCall('register', [$type ?? $attribute['type'], new Reference($id)]);

--- a/src/Bundle/DependencyInjection/Compiler/RegisterFiltersPass.php
+++ b/src/Bundle/DependencyInjection/Compiler/RegisterFiltersPass.php
@@ -29,26 +29,15 @@ final class RegisterFiltersPass implements CompilerPassInterface
             return;
         }
 
-        $registry = $container->getDefinition('sylius.registry.grid_filter');
+        $filterRegistry = $container->getDefinition('sylius.registry.grid_filter');
         $formTypeRegistry = $container->getDefinition('sylius.form_registry.grid_filter');
 
         foreach ($container->findTaggedServiceIds(AsFilter::SERVICE_TAG) as $id => $attributes) {
-            $this->registerFilter($registry, $formTypeRegistry, $id, $attributes);
-        }
-
-        foreach ($container->findTaggedServiceIds('sylius.legacy_grid_filter') as $id => $attributes) {
-            $definition = $container->findDefinition($id);
-
-            // Already configured with "sylius.grid_filter" tag.
-            if ($definition->hasTag(AsFilter::SERVICE_TAG)) {
-                continue;
-            }
+            $definition = $container->getDefinition($id);
+            $class = $definition->getClass();
 
             $type = null;
             $formType = null;
-
-            $definition = $container->getDefinition($id);
-            $class = $definition->getClass();
 
             if ($class !== null && is_a($class, TypeAwareFilterInterface::class, true)) {
                 $type = $class::getType();
@@ -58,7 +47,7 @@ final class RegisterFiltersPass implements CompilerPassInterface
                 $formType = $class::getFormType();
             }
 
-            $this->registerFilter($registry, $formTypeRegistry, $id, $attributes, $type, $formType);
+            $this->registerFilter($filterRegistry, $formTypeRegistry, $id, $attributes, $type, $formType);
         }
     }
 

--- a/src/Bundle/DependencyInjection/SyliusGridExtension.php
+++ b/src/Bundle/DependencyInjection/SyliusGridExtension.php
@@ -78,7 +78,7 @@ final class SyliusGridExtension extends Extension
         );
 
         $container->registerForAutoconfiguration(FilterInterface::class)
-            ->addTag('sylius.grid_filter')
+            ->addTag('sylius.legacy_grid_filter')
         ;
 
         $container->registerForAutoconfiguration(DataProviderInterface::class)

--- a/src/Bundle/DependencyInjection/SyliusGridExtension.php
+++ b/src/Bundle/DependencyInjection/SyliusGridExtension.php
@@ -71,8 +71,8 @@ final class SyliusGridExtension extends Extension
                 }
 
                 $definition->addTag(AsFilter::SERVICE_TAG, [
-                'type' => $attribute->getType() ?? $reflector->getName(),
-                'form_type' => $attribute->getFormType(),
+                    'type' => $attribute->type ?? $reflector->getName(),
+                    'form_type' => $attribute->formType,
                 ]);
             },
         );

--- a/src/Bundle/DependencyInjection/SyliusGridExtension.php
+++ b/src/Bundle/DependencyInjection/SyliusGridExtension.php
@@ -16,9 +16,11 @@ namespace Sylius\Bundle\GridBundle\DependencyInjection;
 use Sylius\Bundle\CurrencyBundle\SyliusCurrencyBundle;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 use Sylius\Bundle\GridBundle\SyliusGridBundle;
+use Sylius\Component\Grid\Attribute\AsFilter;
 use Sylius\Component\Grid\Data\DataProviderInterface;
 use Sylius\Component\Grid\Filtering\FilterInterface;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -59,6 +61,21 @@ final class SyliusGridExtension extends Extension
         $container->registerForAutoconfiguration(GridInterface::class)
             ->addTag('sylius.grid')
         ;
+
+        $container->registerAttributeForAutoconfiguration(
+            AsFilter::class,
+            static function (ChildDefinition $definition, AsFilter $attribute, \Reflector $reflector): void {
+                // Helps to avoid issues with psalm
+                if (!$reflector instanceof \ReflectionClass) {
+                    return;
+                }
+
+                $definition->addTag(AsFilter::SERVICE_TAG, [
+                'type' => $attribute->getType() ?? $reflector->getName(),
+                'form_type' => $attribute->getFormType(),
+                ]);
+            },
+        );
 
         $container->registerForAutoconfiguration(FilterInterface::class)
             ->addTag('sylius.grid_filter')

--- a/src/Bundle/DependencyInjection/SyliusGridExtension.php
+++ b/src/Bundle/DependencyInjection/SyliusGridExtension.php
@@ -78,7 +78,7 @@ final class SyliusGridExtension extends Extension
         );
 
         $container->registerForAutoconfiguration(ConfigurableFilterInterface::class)
-            ->addTag('sylius.legacy_grid_filter')
+            ->addTag(AsFilter::SERVICE_TAG)
         ;
 
         $container->registerForAutoconfiguration(DataProviderInterface::class)

--- a/src/Bundle/DependencyInjection/SyliusGridExtension.php
+++ b/src/Bundle/DependencyInjection/SyliusGridExtension.php
@@ -18,7 +18,7 @@ use Sylius\Bundle\GridBundle\Grid\GridInterface;
 use Sylius\Bundle\GridBundle\SyliusGridBundle;
 use Sylius\Component\Grid\Attribute\AsFilter;
 use Sylius\Component\Grid\Data\DataProviderInterface;
-use Sylius\Component\Grid\Filtering\FilterInterface;
+use Sylius\Component\Grid\Filtering\ConfigurableFilterInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -77,7 +77,7 @@ final class SyliusGridExtension extends Extension
             },
         );
 
-        $container->registerForAutoconfiguration(FilterInterface::class)
+        $container->registerForAutoconfiguration(ConfigurableFilterInterface::class)
             ->addTag('sylius.legacy_grid_filter')
         ;
 

--- a/src/Bundle/Tests/DependencyInjection/Compiler/RegisterFiltersPassTest.php
+++ b/src/Bundle/Tests/DependencyInjection/Compiler/RegisterFiltersPassTest.php
@@ -13,14 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\GridBundle\Tests\DependencyInjection\Compiler;
 
-use App\Filter\AttributeNationalityFilter;
 use App\Filter\Foo;
 use App\Filter\NationalityFilter;
 use App\Grid\Type\NationalityFilterType;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\RegisterFiltersPass;
-use Sylius\Component\Grid\Filtering\FormTypeAwareFilterInterface;
-use Sylius\Component\Grid\Filtering\TypeAwareFilterInterface;
 use Sylius\Component\Registry\ServiceRegistry;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -76,18 +73,15 @@ final class RegisterFiltersPassTest extends AbstractCompilerPassTestCase
     /**
      * @test
      */
-    public function it_autoconfigures_a_legacy_grid_filter(): void
+    public function it_autoconfigures_a_grid_filter(): void
     {
         $this->registerService(NationalityFilter::class, NationalityFilter::class)
-            ->addTag('sylius.legacy_grid_filter')
+            ->addTag('sylius.grid_filter')
         ;
 
-        $filterRegistryServiceId = 'sylius.registry.grid_filter';
-        $filterFormTypeRegistryServiceId = 'sylius.form_registry.grid_filter';
-
-        $this->registerService($filterRegistryServiceId, ServiceRegistry::class);
+        $this->registerService($filterRegistryServiceId = 'sylius.registry.grid_filter', ServiceRegistry::class);
         $this->registerService(
-            $filterFormTypeRegistryServiceId,
+            $filterFormTypeRegistryServiceId = 'sylius.form_registry.grid_filter',
             ServiceRegistry::class,
         );
 
@@ -113,97 +107,6 @@ final class RegisterFiltersPassTest extends AbstractCompilerPassTestCase
                 NationalityFilterType::class,
             ],
         );
-    }
-
-    /**
-     * @test
-     */
-    public function it_autoconfigures_a_grid_filter(): void
-    {
-        $this->registerService(AttributeNationalityFilter::class, AttributeNationalityFilter::class)
-            ->addTag('sylius.grid_filter', ['form_type' => NationalityFilterType::class, 'type' => AttributeNationalityFilter::class])
-            ->addTag('sylius.legacy_grid_filter')
-        ;
-
-        $filterRegistryServiceId = 'sylius.registry.grid_filter';
-        $filterFormTypeRegistryServiceId = 'sylius.form_registry.grid_filter';
-
-        $this->registerService($filterRegistryServiceId, ServiceRegistry::class);
-        $this->registerService(
-            $filterFormTypeRegistryServiceId,
-            ServiceRegistry::class,
-        );
-
-        $this->compile();
-
-        // Filter
-        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
-            $filterRegistryServiceId,
-            'register',
-            [
-                AttributeNationalityFilter::class,
-                new Reference(AttributeNationalityFilter::class),
-            ],
-        );
-
-        // Form Type
-        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
-            $filterFormTypeRegistryServiceId,
-            'add',
-            [
-                AttributeNationalityFilter::class,
-                'default',
-                NationalityFilterType::class,
-            ],
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function it_throws_an_exception_when_grid_filter_has_no_type_attribute(): void
-    {
-        $this->registerService(Foo::class, Foo::class)
-            ->addTag('sylius.grid_filter')
-        ;
-
-        $filterRegistryServiceId = 'sylius.registry.grid_filter';
-        $filterFormTypeRegistryServiceId = 'sylius.form_registry.grid_filter';
-
-        $this->registerService($filterRegistryServiceId, ServiceRegistry::class);
-        $this->registerService(
-            $filterFormTypeRegistryServiceId,
-            ServiceRegistry::class,
-        );
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('Tagged grid filters needs to have "type" attribute or implements "%s".', TypeAwareFilterInterface::class));
-
-        $this->compile();
-    }
-
-    /**
-     * @test
-     */
-    public function it_throws_an_exception_when_grid_filter_has_no_form_type_attribute(): void
-    {
-        $this->registerService(Foo::class, Foo::class)
-            ->addTag('sylius.grid_filter', ['type' => Foo::class])
-        ;
-
-        $filterRegistryServiceId = 'sylius.registry.grid_filter';
-        $filterFormTypeRegistryServiceId = 'sylius.form_registry.grid_filter';
-
-        $this->registerService($filterRegistryServiceId, ServiceRegistry::class);
-        $this->registerService(
-            $filterFormTypeRegistryServiceId,
-            ServiceRegistry::class,
-        );
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('Tagged grid filters needs to have "form_type" attribute or implements "%s".', FormTypeAwareFilterInterface::class));
-
-        $this->compile();
     }
 
     protected function registerCompilerPass(ContainerBuilder $container): void

--- a/src/Component/Attribute/AsFilter.php
+++ b/src/Component/Attribute/AsFilter.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class AsFilter
+{
+    public const SERVICE_TAG = 'sylius.grid.filter';
+
+    /**
+     * @param class-string $formType The form type class name to use for filter rendering
+     */
+    public function __construct(
+        private readonly string $formType,
+        private readonly ?string $type = null,
+    ) {
+    }
+
+    public function getFormType(): string
+    {
+        return $this->formType;
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+}

--- a/src/Component/Attribute/AsFilter.php
+++ b/src/Component/Attribute/AsFilter.php
@@ -22,18 +22,8 @@ final class AsFilter
      * @param class-string $formType The form type class name to use for filter rendering
      */
     public function __construct(
-        private readonly string $formType,
-        private readonly ?string $type = null,
+        public readonly string $formType,
+        public readonly ?string $type = null,
     ) {
-    }
-
-    public function getFormType(): string
-    {
-        return $this->formType;
-    }
-
-    public function getType(): ?string
-    {
-        return $this->type;
     }
 }

--- a/src/Component/Attribute/AsFilter.php
+++ b/src/Component/Attribute/AsFilter.php
@@ -16,7 +16,7 @@ namespace Sylius\Component\Grid\Attribute;
 #[\Attribute(\Attribute::TARGET_CLASS)]
 final class AsFilter
 {
-    public const SERVICE_TAG = 'sylius.grid.filter';
+    public const SERVICE_TAG = 'sylius.grid_filter';
 
     /**
      * @param class-string $formType The form type class name to use for filter rendering

--- a/tests/Application/config/services.yaml
+++ b/tests/Application/config/services.yaml
@@ -25,6 +25,7 @@ services:
             - '@app.repository.author'
         public: true
 
+    App\Filter\AttributeNationalityFilter: null
     App\Filter\NationalityFilter: null
 
     App\BoardGameBlog\:

--- a/tests/Application/config/sylius/grids/book.php
+++ b/tests/Application/config/sylius/grids/book.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 use App\Entity\Author;
 use App\Entity\Book;
+use App\Grid\Builder\AttributeNationalityFilter;
 use App\Grid\Builder\NationalityFilter;
 use Sylius\Bundle\GridBundle\Builder\Field\StringField;
 use Sylius\Bundle\GridBundle\Builder\Filter\EntityFilter;
@@ -28,6 +29,11 @@ return static function (GridConfig $grid) {
         ->addFilter(EntityFilter::create('author', Author::class, true))
         ->addFilter(NationalityFilter::create(
             'nationality',
+            null,
+            ['author.nationality'],
+        ))
+        ->addFilter(AttributeNationalityFilter::create(
+            AttributeNationalityFilter::class,
             null,
             ['author.nationality'],
         ))

--- a/tests/Application/src/Filter/AttributeNationalityFilter.php
+++ b/tests/Application/src/Filter/AttributeNationalityFilter.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App\Filter;
+
+use App\Grid\Type\NationalityFilterType;
+use Sylius\Component\Grid\Attribute\AsFilter;
+use Sylius\Component\Grid\Data\DataSourceInterface;
+use Sylius\Component\Grid\Filter\EntityFilter;
+use Sylius\Component\Grid\Filtering\FilterInterface;
+
+#[AsFilter(
+    formType: NationalityFilterType::class,
+)]
+final class AttributeNationalityFilter implements FilterInterface
+{
+    public function __construct(private EntityFilter $decorated)
+    {
+    }
+
+    public function apply(DataSourceInterface $dataSource, string $name, $data, array $options): void
+    {
+        $this->decorated->apply($dataSource, $name, $data, $options);
+    }
+}

--- a/tests/Application/src/Grid/Builder/AttributeNationalityFilter.php
+++ b/tests/Application/src/Grid/Builder/AttributeNationalityFilter.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App\Grid\Builder;
+
+use App\Entity\Nationality;
+use App\Filter\AttributeNationalityFilter as GridNationalityFilter;
+use Sylius\Bundle\GridBundle\Builder\Filter\Filter;
+use Sylius\Bundle\GridBundle\Builder\Filter\FilterInterface;
+
+final class AttributeNationalityFilter
+{
+    public static function create(string $name, ?bool $multiple = null, ?array $fields = null): FilterInterface
+    {
+        $filter = Filter::create($name, GridNationalityFilter::class);
+
+        $filter->setFormOptions(['class' => Nationality::class]);
+
+        if (null !== $fields) {
+            $filter->setOptions(['fields' => $fields]);
+        }
+
+        if (null !== $multiple) {
+            $filter->addFormOption('multiple', $multiple);
+        }
+
+        return $filter;
+    }
+}


### PR DESCRIPTION
This PR introduces a new attribute, `AsFilter`, to provide a more concise and structured way of defining filter types and form types for grid filters.

Previously, filter types and form types were defined two methods inherited from `ConfigurableFilterInterface`.

By using the `AsFilter` attribute, developers can now explicitly declare the type and form type of a filter directly above the class definition. This approach improves code readability, reduces reliance on tag attributes, and enhances maintainability.

**Steps:**
- [x] Create the attribute and implement it's logic
- [x] Test
- [ ] Documentation (should be on Sylius stack now)

**Example usage:**

```php
use Sylius\Component\Grid\Filtering\FilterInterface;
use Sylius\Component\Grid\Metadata\AsFilter;

#[AsFilter(type: 'product_name', formType: ProductNameFilterType::class)]
final class ProductNameFilter implements FilterInterface
{
    public function apply(DataSourceInterface $dataSource, string $name, $data, array $options): void
    {
        if (empty($data['value'])) {
            return;
        }

        $queryBuilder = $dataSource->getQueryBuilder();
        $rootAlias = $queryBuilder->getRootAliases()[0];

        $queryBuilder
            ->andWhere(sprintf('%s.name LIKE :name', $rootAlias))
            ->setParameter('name', '%' . $data['value'] . '%');
    }
}
```

The `RegisterFiltersPass` compiler pass has been updated to check for the `AsFilter` attribute and ignore duplicate filter configuration.

Tests are provided in the PR, documentation too.

A new behaviour is that type is now optional as the FQCN is now used by default. Which means you can reference it directly in [PHP](https://github.com/Sylius/SyliusGridBundle/pull/348/files#diff-77aaeac60781f223afad001a87631ddf56d09651d5263d8b629f58c4d7354996R36) or [YAML](https://github.com/Sylius/SyliusGridBundle/pull/348/files#diff-96c3d347bc202eff3ed01bc089a7e1980297ccf35751e855bbc5049a1d5bd91fR111) .

**Future considerations:**

In a future PR, we can consider deprecating the `ConfigurableFilterInterface` as it becomes redundant by introducing the `AsFilter` attribute. This will further simplify the process of creating grid filters and improve consistency.
