### PR TITLE
Introduce AsGrid attribute for streamlined grid configuration

### DIFF
--- a/docs/your_first_grid.md
+++ b/docs/your_first_grid.md
@@ -112,14 +112,11 @@ use Sylius\Bundle\GridBundle\Builder\Field\TwigField;
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\AbstractGrid;
 use Sylius\Bundle\GridBundle\Grid\ResourceAwareGridInterface;
+use Sylius\Component\Grid\Attribute\AsGrid;
 
-final class AdminSupplierGrid extends AbstractGrid implements ResourceAwareGridInterface
+#[AsGrid('app_admin_supplier', Supplier::class)]
+final class AdminSupplierGrid extends AbstractGrid
 {
-    public static function getName(): string
-    {
-           return 'app_admin_supplier';
-    }
-
     public function buildGrid(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
@@ -132,11 +129,6 @@ final class AdminSupplierGrid extends AbstractGrid implements ResourceAwareGridI
                     ->setLabel('sylius.ui.enabled')
             )
         ;
-    }
-
-    public function getResourceClass(): string
-    {
-        return Supplier::class;
     }
 }
 ```

--- a/src/Bundle/Grid/AbstractGrid.php
+++ b/src/Bundle/Grid/AbstractGrid.php
@@ -22,7 +22,7 @@ abstract class AbstractGrid implements GridInterface
     public static function getName(): string
     {
         if ($attribute = self::getAttributes()) {
-            return $attribute[0]->newInstance()->getName();
+            return $attribute[0]?->newInstance()->name ?? static::class;
         }
 
         return static::class;
@@ -31,7 +31,7 @@ abstract class AbstractGrid implements GridInterface
     public function getResourceClass(): string
     {
         if ($attribute = self::getAttributes()) {
-            return $attribute[0]->newInstance()->getResourceClass();
+            return $attribute[0]->newInstance()->resourceClass;
         }
 
         throw new \LogicException(sprintf(

--- a/src/Bundle/Grid/AbstractGrid.php
+++ b/src/Bundle/Grid/AbstractGrid.php
@@ -15,9 +15,32 @@ namespace Sylius\Bundle\GridBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilder;
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
+use Sylius\Component\Grid\Attribute\AsGrid;
 
 abstract class AbstractGrid implements GridInterface
 {
+    public static function getName(): string
+    {
+        if ($attribute = self::getAttributes()) {
+            return $attribute[0]->newInstance()->getName();
+        }
+
+        return static::class;
+    }
+
+    public function getResourceClass(): string
+    {
+        if ($attribute = self::getAttributes()) {
+            return $attribute[0]->newInstance()->getResourceClass();
+        }
+
+        throw new \LogicException(sprintf(
+            'You have to implement %s method or use %s attribute.',
+            __METHOD__,
+            AsGrid::class,
+        ));
+    }
+
     public function toArray(): array
     {
         $gridBuilder = $this->createGridBuilder();
@@ -29,10 +52,18 @@ abstract class AbstractGrid implements GridInterface
 
     private function createGridBuilder(): GridBuilderInterface
     {
-        if ($this instanceof ResourceAwareGridInterface) {
+        if ($this instanceof ResourceAwareGridInterface || $this::getAttributes() !== []) {
             return GridBuilder::create($this::getName(), $this->getResourceClass());
         }
 
         return GridBuilder::create($this::getName());
+    }
+
+    /**
+     * @return \ReflectionAttribute<AsGrid>[]
+     */
+    private static function getAttributes(): array
+    {
+        return (new \ReflectionClass(static::class))->getAttributes(AsGrid::class);
     }
 }

--- a/src/Bundle/Grid/AbstractGrid.php
+++ b/src/Bundle/Grid/AbstractGrid.php
@@ -21,24 +21,7 @@ abstract class AbstractGrid implements GridInterface
 {
     public static function getName(): string
     {
-        if ($attribute = self::getAttributes()) {
-            return $attribute[0]?->newInstance()->name ?? static::class;
-        }
-
-        return static::class;
-    }
-
-    public function getResourceClass(): string
-    {
-        if ($attribute = self::getAttributes()) {
-            return $attribute[0]->newInstance()->resourceClass;
-        }
-
-        throw new \LogicException(sprintf(
-            'You have to implement %s method or use %s attribute.',
-            __METHOD__,
-            AsGrid::class,
-        ));
+        return self::getAsGridAttribute()?->name ?? static::class;
     }
 
     public function toArray(): array
@@ -52,18 +35,19 @@ abstract class AbstractGrid implements GridInterface
 
     private function createGridBuilder(): GridBuilderInterface
     {
-        if ($this instanceof ResourceAwareGridInterface || $this::getAttributes() !== []) {
-            return GridBuilder::create($this::getName(), $this->getResourceClass());
+        $resourceClass = self::getAsGridAttribute()?->resourceClass ?? null;
+
+        if (null === $resourceClass && $this instanceof ResourceAwareGridInterface) {
+            $resourceClass = $this->getResourceClass();
         }
 
-        return GridBuilder::create($this::getName());
+        return GridBuilder::create($this::getName(), $resourceClass);
     }
 
-    /**
-     * @return \ReflectionAttribute<AsGrid>[]
-     */
-    private static function getAttributes(): array
+    private static function getAsGridAttribute(): ?AsGrid
     {
-        return (new \ReflectionClass(static::class))->getAttributes(AsGrid::class);
+        $reflection = (new \ReflectionClass(static::class))->getAttributes(AsGrid::class)[0] ?? null;
+
+        return $reflection?->newInstance();
     }
 }

--- a/src/Bundle/Tests/DependencyInjection/GridBuilderConfigurationTest.php
+++ b/src/Bundle/Tests/DependencyInjection/GridBuilderConfigurationTest.php
@@ -913,12 +913,12 @@ final class GridBuilderConfigurationTest extends AbstractExtensionTestCase
 
         $this->load([
             'grids' => [
-                'app_foo_with_attribute' => $grid->toArray(),
+                AttributeFooGrid::class => $grid->toArray(),
             ],
         ]);
 
         $this->assertContainerBuilderHasParameter('sylius.grids_definitions', [
-            'app_foo_with_attribute' => [
+            AttributeFooGrid::class => [
                 'driver' => [
                     'name' => Driver::NAME,
                     'options' => [

--- a/src/Bundle/Tests/DependencyInjection/GridBuilderConfigurationTest.php
+++ b/src/Bundle/Tests/DependencyInjection/GridBuilderConfigurationTest.php
@@ -39,6 +39,7 @@ use Sylius\Bundle\GridBundle\Builder\Filter\StringFilter;
 use Sylius\Bundle\GridBundle\Builder\GridBuilder;
 use Sylius\Bundle\GridBundle\DependencyInjection\SyliusGridExtension;
 use Sylius\Bundle\GridBundle\Doctrine\ORM\Driver;
+use Sylius\Component\Grid\Tests\Dummy\AttributeFooGrid;
 use Sylius\Component\Grid\Tests\Dummy\ClassAsParameterGrid;
 use Sylius\Component\Grid\Tests\Dummy\Foo;
 use Sylius\Component\Grid\Tests\Dummy\FooFightersGrid;
@@ -897,6 +898,37 @@ final class GridBuilderConfigurationTest extends AbstractExtensionTestCase
                         'options' => [],
                     ],
                 ],
+                'filters' => [],
+                'actions' => [],
+            ],
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_builds_grid_with_a_grid_attribute(): void
+    {
+        $grid = new AttributeFooGrid();
+
+        $this->load([
+            'grids' => [
+                'app_foo_with_attribute' => $grid->toArray(),
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasParameter('sylius.grids_definitions', [
+            'app_foo_with_attribute' => [
+                'driver' => [
+                    'name' => Driver::NAME,
+                    'options' => [
+                        'class' => Foo::class,
+                    ],
+                ],
+                'removals' => [],
+                'sorting' => [],
+                'limits' => [10, 25, 50],
+                'fields' => [],
                 'filters' => [],
                 'actions' => [],
             ],

--- a/src/Bundle/Tests/DependencyInjection/GridBuilderConfigurationTest.php
+++ b/src/Bundle/Tests/DependencyInjection/GridBuilderConfigurationTest.php
@@ -39,7 +39,8 @@ use Sylius\Bundle\GridBundle\Builder\Filter\StringFilter;
 use Sylius\Bundle\GridBundle\Builder\GridBuilder;
 use Sylius\Bundle\GridBundle\DependencyInjection\SyliusGridExtension;
 use Sylius\Bundle\GridBundle\Doctrine\ORM\Driver;
-use Sylius\Component\Grid\Tests\Dummy\AttributeFooGrid;
+use Sylius\Component\Grid\Tests\Dummy\AttributeGrid;
+use Sylius\Component\Grid\Tests\Dummy\AttributeWithResourceClassGrid;
 use Sylius\Component\Grid\Tests\Dummy\ClassAsParameterGrid;
 use Sylius\Component\Grid\Tests\Dummy\Foo;
 use Sylius\Component\Grid\Tests\Dummy\FooFightersGrid;
@@ -865,9 +866,7 @@ final class GridBuilderConfigurationTest extends AbstractExtensionTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_builds_extended_grids_with_grids_as_service(): void
     {
         $grid = new FooFightersGrid();
@@ -904,21 +903,46 @@ final class GridBuilderConfigurationTest extends AbstractExtensionTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_builds_grid_with_a_grid_attribute(): void
     {
-        $grid = new AttributeFooGrid();
+        $grid = new AttributeGrid();
 
         $this->load([
             'grids' => [
-                AttributeFooGrid::class => $grid->toArray(),
+                AttributeGrid::class => $grid->toArray(),
             ],
         ]);
 
         $this->assertContainerBuilderHasParameter('sylius.grids_definitions', [
-            AttributeFooGrid::class => [
+            AttributeGrid::class => [
+                'driver' => [
+                    'name' => Driver::NAME,
+                    'options' => [],
+                ],
+                'removals' => [],
+                'sorting' => [],
+                'limits' => [10, 25, 50],
+                'fields' => [],
+                'filters' => [],
+                'actions' => [],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_builds_grid_with_a_grid_attribute_with_defined_resource_class(): void
+    {
+        $grid = new AttributeWithResourceClassGrid();
+
+        $this->load([
+            'grids' => [
+                AttributeWithResourceClassGrid::class => $grid->toArray(),
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasParameter('sylius.grids_definitions', [
+            AttributeWithResourceClassGrid::class => [
                 'driver' => [
                     'name' => Driver::NAME,
                     'options' => [

--- a/src/Component/Attribute/AsGrid.php
+++ b/src/Component/Attribute/AsGrid.php
@@ -17,18 +17,8 @@ namespace Sylius\Component\Grid\Attribute;
 final class AsGrid
 {
     public function __construct(
-        private readonly string $name,
-        private readonly string $resourceClass,
+        public readonly string $resourceClass,
+        public readonly ?string $name = null,
     ) {
-    }
-
-    public function getName(): string
-    {
-        return $this->name;
-    }
-
-    public function getResourceClass(): string
-    {
-        return $this->resourceClass;
     }
 }

--- a/src/Component/Attribute/AsGrid.php
+++ b/src/Component/Attribute/AsGrid.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class AsGrid
+{
+    public function __construct(
+        private readonly string $name,
+        private readonly string $resourceClass,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getResourceClass(): string
+    {
+        return $this->resourceClass;
+    }
+}

--- a/src/Component/Attribute/AsGrid.php
+++ b/src/Component/Attribute/AsGrid.php
@@ -17,7 +17,7 @@ namespace Sylius\Component\Grid\Attribute;
 final class AsGrid
 {
     public function __construct(
-        public readonly string $resourceClass,
+        public readonly ?string $resourceClass = null,
         public readonly ?string $name = null,
     ) {
     }

--- a/src/Component/Definition/ArrayToDefinitionConverter.php
+++ b/src/Component/Definition/ArrayToDefinitionConverter.php
@@ -32,7 +32,7 @@ final class ArrayToDefinitionConverter implements ArrayToDefinitionConverterInte
         $grid = Grid::fromCodeAndDriverConfiguration(
             $code,
             $configuration['driver']['name'],
-            $configuration['driver']['options'],
+            $configuration['driver']['options'] ?? [],
         );
 
         $grid->setProvider($configuration['provider'] ?? null);

--- a/src/Component/Tests/Dummy/AttributeFooGrid.php
+++ b/src/Component/Tests/Dummy/AttributeFooGrid.php
@@ -17,7 +17,7 @@ use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\AbstractGrid;
 use Sylius\Component\Grid\Attribute\AsGrid;
 
-#[AsGrid(name: 'app_foo_with_attribute', resourceClass: Foo::class)]
+#[AsGrid(resourceClass: Foo::class)]
 final class AttributeFooGrid extends AbstractGrid
 {
     public function buildGrid(GridBuilderInterface $gridBuilder): void

--- a/src/Component/Tests/Dummy/AttributeFooGrid.php
+++ b/src/Component/Tests/Dummy/AttributeFooGrid.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Tests\Dummy;
+
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
+use Sylius\Bundle\GridBundle\Grid\AbstractGrid;
+use Sylius\Component\Grid\Attribute\AsGrid;
+
+#[AsGrid(name: 'app_foo_with_attribute', resourceClass: Foo::class)]
+final class AttributeFooGrid extends AbstractGrid
+{
+    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    {
+    }
+}

--- a/src/Component/Tests/Dummy/AttributeGrid.php
+++ b/src/Component/Tests/Dummy/AttributeGrid.php
@@ -17,8 +17,8 @@ use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\AbstractGrid;
 use Sylius\Component\Grid\Attribute\AsGrid;
 
-#[AsGrid(resourceClass: Foo::class)]
-final class AttributeFooGrid extends AbstractGrid
+#[AsGrid]
+final class AttributeGrid extends AbstractGrid
 {
     public function buildGrid(GridBuilderInterface $gridBuilder): void
     {

--- a/src/Component/Tests/Dummy/AttributeWithResourceClassGrid.php
+++ b/src/Component/Tests/Dummy/AttributeWithResourceClassGrid.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Tests\Dummy;
+
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
+use Sylius\Bundle\GridBundle\Grid\AbstractGrid;
+use Sylius\Component\Grid\Attribute\AsGrid;
+
+#[AsGrid(resourceClass: Foo::class)]
+final class AttributeWithResourceClassGrid extends AbstractGrid
+{
+    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    {
+    }
+}


### PR DESCRIPTION
To simplify the configuration of grids and promote code clarity, this PR introduces a new attribute, `AsGrid`, which allows developers to define the grid's name and resource class directly within their grid classes, eliminating the need for YAML configuration files.

Previously, these properties were defined at usage which could cause code duplication.

By using the `AsGrid` attribute, developers can now explicitly declare the name and resource class of a grid directly above the class definition. This approach improves code readability, centralizes configuration, and enhances maintainability.

**Example usage:**

```php
use Sylius\Bundle\GridBundle\Grid\AbstractGrid;
use Sylius\Component\Grid\Metadata\AsGrid;

#[AsGrid(
    resourceClass: Product::class, 
    name: 'app_admin_product',
)]
final class ProductGrid implements AbstractGrid
{
    // ...
}
```

```php
use Sylius\Bundle\GridBundle\Grid\AbstractGrid;
use Sylius\Component\Grid\Metadata\AsGrid;

#[AsGrid]
final class ProductGrid implements AbstractGrid
{
    // ...
}
```

This PR includes comprehensive tests and updated documentation to guide developers on using the new attribute.


**Future considerations:**

In a future PR, we can consider deprecating the YAML-based grid configuration in favor of the attribute-based approach to further streamline the grid creation process and improve consistency.