### PR TITLE
fix grid sorting with sorting key not defined and refactor grid definition creation

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,6 +22,7 @@
         <testsuite name="SyliusGridBundle Test Suite">
             <directory>./tests/</directory>
             <directory>./src/Bundle/Tests/</directory>
+            <directory>./src/Component/Tests/</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/src/Bundle/Factory/ExtenderGridFactory.php
+++ b/src/Bundle/Factory/ExtenderGridFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\GridBundle\Factory;
+
+use Sylius\Bundle\GridBundle\Registry\GridRegistryInterface;
+use Sylius\Component\Grid\Configuration\GridConfigurationExtenderInterface;
+use Sylius\Component\Grid\Definition\Grid;
+use Sylius\Component\Grid\Factory\GridFactoryInterface;
+use Webmozart\Assert\Assert;
+
+final class ExtenderGridFactory implements GridFactoryInterface
+{
+    public function __construct(
+        private GridFactoryInterface $decorated,
+        private GridRegistryInterface $gridRegistry,
+        private array $gridConfigurations,
+        private GridConfigurationExtenderInterface $gridConfigurationExtender,
+    ) {
+    }
+
+    public function create(string $code, array $gridConfiguration): Grid
+    {
+        $parentGridCode = $gridConfiguration['extends'] ?? null;
+
+        if (null !== $parentGridCode) {
+            $parentGridConfiguration = $this->gridRegistry->getGrid($parentGridCode)?->toArray() ?? $this->gridConfigurations[$parentGridCode] ?? null;
+            Assert::notNull($parentGridConfiguration, sprintf('Parent grid with code "%s" does not exists.', $gridConfiguration['extends']));
+
+            $gridConfiguration = $this->gridConfigurationExtender->extends($gridConfiguration, $parentGridConfiguration);
+        }
+
+        return $this->decorated->create($code, $gridConfiguration);
+    }
+}

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -43,20 +43,42 @@
         <service id="sylius.grid.configuration_removals_handler" class="Sylius\Component\Grid\Configuration\GridConfigurationRemovalsHandler"/>
         <service id="Sylius\Component\Grid\Configuration\GridConfigurationRemovalsHandlerInterface" alias="sylius.grid.configuration_removals_handler" />
 
+        <service id="sylius.grid.configuration_sorting_handler" class="Sylius\Component\Grid\Configuration\GridConfigurationSortingHandler"/>
+        <service id="Sylius\Component\Grid\Configuration\GridConfigurationSortingHandlerInterface" alias="sylius.grid.configuration_sorting_handler" />
+
         <service id="sylius.grid.array_grid_provider" class="Sylius\Component\Grid\Provider\ArrayGridProvider">
-            <argument type="service" id="sylius.grid.array_to_definition_converter" />
             <argument>%sylius.grids_definitions%</argument>
-            <argument type="service" id="sylius.grid.configuration_extender" />
-            <argument type="service" id="sylius.grid.configuration_removals_handler" />
+            <argument type="service" id="sylius.grid.grid_factory" />
             <tag name="sylius.grid_provider" key="array" priority="-200"/>
         </service>
         <service id="Sylius\Component\Grid\Provider\ArrayGridProvider" alias="sylius.grid.array_grid_provider" />
 
-        <service id="sylius.grid.service_grid_provider" class="Sylius\Bundle\GridBundle\Provider\ServiceGridProvider">
+        <service id="sylius.grid.grid_factory" class="Sylius\Component\Grid\Factory\GridFactory">
             <argument type="service" id="sylius.grid.array_to_definition_converter" />
+            <argument type="service" id="event_dispatcher" />
+        </service>
+        <service id="Sylius\Component\Grid\Factory\GridFactory" alias="sylius.grid.grid_factory" />
+
+        <service id="Sylius\Bundle\GridBundle\Factory\ExtenderGridFactory" decorates="sylius.grid.grid_factory" decoration-priority="0">
+            <argument type="service" id=".inner" />
             <argument type="service" id="sylius.grid.grid_registry" />
+            <argument>%sylius.grids_definitions%</argument>
             <argument type="service" id="sylius.grid.configuration_extender" />
+        </service>
+
+        <service id="Sylius\Component\Grid\Factory\RemovalsGridFactory" decorates="sylius.grid.grid_factory" decoration-priority="64">
+            <argument type="service" id=".inner" />
             <argument type="service" id="sylius.grid.configuration_removals_handler" />
+        </service>
+
+        <service id="Sylius\Component\Grid\Factory\SortingGridFactory" decorates="sylius.grid.grid_factory" decoration-priority="128">
+            <argument type="service" id=".inner" />
+            <argument type="service" id="sylius.grid.configuration_sorting_handler" />
+        </service>
+
+        <service id="sylius.grid.service_grid_provider" class="Sylius\Bundle\GridBundle\Provider\ServiceGridProvider">
+            <argument type="service" id="sylius.grid.grid_registry" />
+            <argument type="service" id="sylius.grid.grid_factory" />
             <tag name="sylius.grid_provider" key="service" priority="-100"/>
         </service>
         <service id="Sylius\Bundle\GridBundle\Provider\ServiceGridProvider" alias="sylius.grid.service_grid_provider" />

--- a/src/Bundle/spec/Factory/ExtenderGridFactorySpec.php
+++ b/src/Bundle/spec/Factory/ExtenderGridFactorySpec.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\GridBundle\Factory;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\GridBundle\Grid\GridInterface;
+use Sylius\Bundle\GridBundle\Registry\GridRegistryInterface;
+use Sylius\Component\Grid\Configuration\GridConfigurationExtenderInterface;
+use Sylius\Component\Grid\Definition\Grid;
+use Sylius\Component\Grid\Factory\GridFactoryInterface;
+
+final class ExtenderGridFactorySpec extends ObjectBehavior
+{
+    function let(
+        GridFactoryInterface $decorated,
+        GridRegistryInterface $gridRegistry,
+        GridConfigurationExtenderInterface $gridConfigurationExtender,
+    ): void {
+        $this->beConstructedWith(
+            $decorated,
+            $gridRegistry,
+            [
+                'author' => ['foo' => 'foobar'],
+            ],
+            $gridConfigurationExtender,
+        );
+    }
+
+    function it_does_not_update_grid(
+        GridFactoryInterface $decorated,
+        Grid $gridDefinition,
+    ): void {
+        $decorated->create('book', ['config'])->willReturn($gridDefinition);
+
+        $this->create('book', ['config'])->shouldReturn($gridDefinition);
+    }
+
+    function it_updates_grid_with_parent_from_grid_registry(
+        GridFactoryInterface $decorated,
+        GridRegistryInterface $gridRegistry,
+        GridConfigurationExtenderInterface $gridConfigurationExtender,
+        GridInterface $grid,
+        Grid $gridDefinition,
+    ): void {
+        $gridRegistry->getGrid('author')->willReturn($grid);
+        $grid->toArray()->willReturn([
+            'bar' => 'baz',
+        ]);
+
+        $gridConfigurationExtender
+            ->extends(['extends' => 'author'], ['bar' => 'baz'])
+            ->willReturn([
+                'extends' => 'author',
+                'bar' => 'baz',
+            ]);
+
+        $decorated->create('author_with_books', [
+                'extends' => 'author',
+                'bar' => 'baz',
+            ])->willReturn($gridDefinition);
+
+        $this->create('author_with_books', [
+            'extends' => 'author',
+        ])->shouldReturn($gridDefinition);
+    }
+
+    function it_updates_grid_with_parent_from_grid_configurations_array(
+        GridFactoryInterface $decorated,
+        GridConfigurationExtenderInterface $gridConfigurationExtender,
+        Grid $gridDefinition,
+    ): void {
+        $gridConfigurationExtender
+            ->extends(['extends' => 'author'], ['foo' => 'foobar'])
+            ->willReturn([
+                'extends' => 'author',
+                'foo' => 'foobar',
+            ]);
+
+        $decorated->create('author_with_books', [
+                'extends' => 'author',
+                'foo' => 'foobar',
+            ])->willReturn($gridDefinition);
+
+        $this->create('author_with_books', [
+            'extends' => 'author',
+        ])->shouldReturn($gridDefinition);
+    }
+
+    function it_throws_an_invalid_argument_exception_when_parent_grid_is_not_found(): void
+    {
+        $this->shouldThrow(\InvalidArgumentException::class)->during('create', ['sylius_admin_book', [
+            'extends' => 'not_existing_grid_code',
+        ]]);
+    }
+}

--- a/src/Component/Configuration/GridConfigurationSortingHandler.php
+++ b/src/Component/Configuration/GridConfigurationSortingHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Configuration;
+
+use Webmozart\Assert\Assert;
+
+final class GridConfigurationSortingHandler implements GridConfigurationSortingHandlerInterface
+{
+    public function handle(array $gridConfiguration): array
+    {
+        if (false === isset($gridConfiguration['sorting'])) {
+            return $gridConfiguration;
+        }
+
+        foreach ($gridConfiguration['sorting'] as $sorting => $order) {
+            Assert::keyExists($gridConfiguration['fields'] ?? [], $sorting);
+
+            $gridConfiguration['fields'][$sorting]['sortable'] = true;
+        }
+
+        return $gridConfiguration;
+    }
+}

--- a/src/Component/Configuration/GridConfigurationSortingHandlerInterface.php
+++ b/src/Component/Configuration/GridConfigurationSortingHandlerInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Configuration;
+
+interface GridConfigurationSortingHandlerInterface
+{
+    public function handle(array $gridConfiguration): array;
+}

--- a/src/Component/Factory/GridConfigurationProcessEvent.php
+++ b/src/Component/Factory/GridConfigurationProcessEvent.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Factory;
+
+use SyliusLabs\Polyfill\Symfony\EventDispatcher\Event;
+
+final class GridConfigurationProcessEvent extends Event
+{
+    public function __construct(
+        private string $gridCode,
+        private array $gridConfiguration,
+    ) {
+    }
+
+    public function getGridCode(): string
+    {
+        return $this->gridCode;
+    }
+
+    public function getGridConfiguration(): array
+    {
+        return $this->gridConfiguration;
+    }
+
+    public function setGridConfiguration(array $gridConfiguration): void
+    {
+        $this->gridConfiguration = $gridConfiguration;
+    }
+}

--- a/src/Component/Factory/GridFactory.php
+++ b/src/Component/Factory/GridFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Factory;
+
+use Sylius\Component\Grid\Definition\ArrayToDefinitionConverterInterface;
+use Sylius\Component\Grid\Definition\Grid;
+
+final class GridFactory implements GridFactoryInterface
+{
+    public function __construct(
+        private ArrayToDefinitionConverterInterface $converter,
+    ) {
+    }
+
+    public function create(string $code, array $gridConfiguration): Grid
+    {
+        return $this->converter->convert($code, $gridConfiguration);
+    }
+}

--- a/src/Component/Factory/GridFactoryInterface.php
+++ b/src/Component/Factory/GridFactoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Factory;
+
+use Sylius\Component\Grid\Definition\Grid;
+
+interface GridFactoryInterface
+{
+    public function create(string $code, array $gridConfiguration): Grid;
+}

--- a/src/Component/Factory/RemovalsGridFactory.php
+++ b/src/Component/Factory/RemovalsGridFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Factory;
+
+use Sylius\Component\Grid\Configuration\GridConfigurationRemovalsHandlerInterface;
+use Sylius\Component\Grid\Definition\Grid;
+
+final class RemovalsGridFactory implements GridFactoryInterface
+{
+    public function __construct(
+        private GridFactoryInterface $decorated,
+        private GridConfigurationRemovalsHandlerInterface $gridConfigurationRemovalsHandler,
+    ) {
+    }
+
+    public function create(string $code, array $gridConfiguration): Grid
+    {
+        $gridConfiguration = $this->gridConfigurationRemovalsHandler->handle($gridConfiguration);
+
+        return $this->decorated->create($code, $gridConfiguration);
+    }
+}

--- a/src/Component/Factory/SortingGridFactory.php
+++ b/src/Component/Factory/SortingGridFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Factory;
+
+use Sylius\Component\Grid\Configuration\GridConfigurationSortingHandlerInterface;
+use Sylius\Component\Grid\Definition\Grid;
+
+final class SortingGridFactory implements GridFactoryInterface
+{
+    public function __construct(
+        private GridFactoryInterface $decorated,
+        private GridConfigurationSortingHandlerInterface $gridConfigurationSortingHandler,
+    ) {
+    }
+
+    public function create(string $code, array $gridConfiguration): Grid
+    {
+        $gridConfiguration = $this->gridConfigurationSortingHandler->handle($gridConfiguration);
+
+        return $this->decorated->create($code, $gridConfiguration);
+    }
+}

--- a/src/Component/spec/Configuration/GridConfigurationSortingHandlerSpec.php
+++ b/src/Component/spec/Configuration/GridConfigurationSortingHandlerSpec.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Grid\Configuration;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Grid\Configuration\GridConfigurationSortingHandler;
+
+final class GridConfigurationSortingHandlerSpec extends ObjectBehavior
+{
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(GridConfigurationSortingHandler::class);
+    }
+
+    function it_adds_sorting(): void
+    {
+        $gridConfiguration = [
+            'fields' => [
+                'title' => [],
+                'author' => ['sortable' => false],
+                'price' => ['sortable' => true],
+            ],
+            'sorting' => [
+                'title' => 'asc',
+                'author' => 'asc',
+                'price' => 'asc',
+            ],
+        ];
+
+        $this->handle($gridConfiguration)->shouldReturn([
+            'fields' => [
+                'title' => ['sortable' => true],
+                'author' => ['sortable' => true],
+                'price' => ['sortable' => true],
+            ],
+            'sorting' => [
+                'title' => 'asc',
+                'author' => 'asc',
+                'price' => 'asc',
+            ],
+        ]);
+    }
+}

--- a/src/Component/spec/Factory/GridFactorySpec.php
+++ b/src/Component/spec/Factory/GridFactorySpec.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Grid\Factory;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Grid\Definition\ArrayToDefinitionConverterInterface;
+use Sylius\Component\Grid\Definition\Grid;
+
+final class GridFactorySpec extends ObjectBehavior
+{
+    function let(
+        ArrayToDefinitionConverterInterface $converter,
+    ): void {
+        $this->beConstructedWith($converter);
+    }
+
+    function it_creates_a_grid(
+        ArrayToDefinitionConverterInterface $converter,
+        Grid $grid,
+    ): void {
+        $converter->convert('foo', ['config'])->willReturn($grid);
+
+        $this->create('foo', ['config'])->shouldReturn($grid);
+    }
+}

--- a/src/Component/spec/Factory/RemovalsGridFactorySpec.php
+++ b/src/Component/spec/Factory/RemovalsGridFactorySpec.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Grid\Factory;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Grid\Configuration\GridConfigurationRemovalsHandlerInterface;
+use Sylius\Component\Grid\Definition\Grid;
+use Sylius\Component\Grid\Factory\GridFactoryInterface;
+
+final class RemovalsGridFactorySpec extends ObjectBehavior
+{
+    function let(
+        GridFactoryInterface $decorated,
+        GridConfigurationRemovalsHandlerInterface $gridConfigurationRemovalsHandler,
+    ): void {
+        $this->beConstructedWith($decorated, $gridConfigurationRemovalsHandler);
+    }
+
+    function it_implements_grid_factory_interface(): void
+    {
+        $this->shouldHaveType(GridFactoryInterface::class);
+    }
+
+    function it_creates_a_grid(
+        GridFactoryInterface $decorated,
+        GridConfigurationRemovalsHandlerInterface $gridConfigurationRemovalsHandler,
+        Grid $grid,
+    ): void {
+        $gridConfigurationRemovalsHandler->handle(['initial_config'])->willReturn(['new_config']);
+
+        $decorated->create('foo', ['new_config'])->willReturn($grid);
+
+        $this->create('foo', ['initial_config'])->shouldReturn($grid);
+    }
+}

--- a/src/Component/spec/Factory/SortingGridFactorySpec.php
+++ b/src/Component/spec/Factory/SortingGridFactorySpec.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Grid\Factory;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Grid\Configuration\GridConfigurationSortingHandlerInterface;
+use Sylius\Component\Grid\Definition\Grid;
+use Sylius\Component\Grid\Factory\GridFactoryInterface;
+
+final class SortingGridFactorySpec extends ObjectBehavior
+{
+    function let(
+        GridFactoryInterface $decorated,
+        GridConfigurationSortingHandlerInterface $gridConfigurationSortingHandler,
+    ): void {
+        $this->beConstructedWith($decorated, $gridConfigurationSortingHandler);
+    }
+
+    function it_implements_grid_factory_interface(): void
+    {
+        $this->shouldHaveType(GridFactoryInterface::class);
+    }
+
+    function it_creates_a_grid(
+        GridFactoryInterface $decorated,
+        GridConfigurationSortingHandlerInterface $gridConfigurationSortingHandler,
+        Grid $grid,
+    ): void {
+        $gridConfigurationSortingHandler->handle(['initial_config'])->willReturn(['new_config']);
+
+        $decorated->create('foo', ['new_config'])->willReturn($grid);
+
+        $this->create('foo', ['initial_config'])->shouldReturn($grid);
+    }
+}

--- a/src/Component/spec/Provider/ArrayGridProviderSpec.php
+++ b/src/Component/spec/Provider/ArrayGridProviderSpec.php
@@ -14,76 +14,43 @@ declare(strict_types=1);
 namespace spec\Sylius\Component\Grid\Provider;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\Component\Grid\Configuration\GridConfigurationExtender;
-use Sylius\Component\Grid\Configuration\GridConfigurationRemovalsHandlerInterface;
-use Sylius\Component\Grid\Definition\ArrayToDefinitionConverterInterface;
 use Sylius\Component\Grid\Definition\Grid;
 use Sylius\Component\Grid\Exception\UndefinedGridException;
+use Sylius\Component\Grid\Factory\GridFactoryInterface;
 use Sylius\Component\Grid\Provider\GridProviderInterface;
 
 final class ArrayGridProviderSpec extends ObjectBehavior
 {
     function let(
-        ArrayToDefinitionConverterInterface $converter,
-        GridConfigurationRemovalsHandlerInterface $gridConfigurationRemovalsHandler,
+        GridFactoryInterface $gridFactory,
         Grid $firstGrid,
         Grid $secondGrid,
         Grid $thirdGrid,
-        Grid $fourthGrid,
-        Grid $fifthGrid,
-        Grid $sixthGrid,
     ): void {
-        $converter->convert('sylius_admin_tax_category', ['configuration1'])->willReturn($firstGrid);
-        $converter->convert('sylius_admin_product', ['configuration2' => 'foo'])->willReturn($secondGrid);
-        $converter->convert('sylius_admin_order', ['configuration3'])->willReturn($thirdGrid);
-        $converter->convert('sylius_admin_product_from_taxon', ['configuration4' => 'bar', 'configuration2' => 'foo'])->willReturn($fourthGrid);
-        $converter->convert('sylius_admin_book', ['extends' => '404'])->willReturn($fifthGrid);
-        $converter->convert('sylius_admin_customer', ['fields' => []])->willReturn($sixthGrid);
-
-        $gridConfigurationRemovalsHandler->handle(['configuration1'])->willReturn(['configuration1']);
-        $gridConfigurationRemovalsHandler->handle(['configuration2' => 'foo'])->willReturn(['configuration2' => 'foo']);
-        $gridConfigurationRemovalsHandler->handle(['configuration3'])->willReturn(['configuration3']);
-        $gridConfigurationRemovalsHandler->handle(['configuration4' => 'bar', 'configuration2' => 'foo'])->willReturn(['configuration4' => 'bar', 'configuration2' => 'foo']);
-        $gridConfigurationRemovalsHandler->handle(['extends' => '404'])->willReturn(['extends' => '404']);
-        $gridConfigurationRemovalsHandler->handle([
-            'fields' => ['customer' => []],
-            'removals' => [
-                'fields' => ['customer'],
-            ],
-        ])->willReturn([
-            'fields' => [],
-        ]);
+        $gridFactory->create('sylius_admin_tax_category', ['configuration1'])->willReturn($firstGrid);
+        $gridFactory->create('sylius_admin_product', ['configuration2' => 'foo'])->willReturn($secondGrid);
+        $gridFactory->create('sylius_admin_order', ['configuration3'])->willReturn($thirdGrid);
 
         $this->beConstructedWith(
-            $converter,
             [
                 'sylius_admin_tax_category' => ['configuration1'],
                 'sylius_admin_product' => ['configuration2' => 'foo'],
                 'sylius_admin_order' => ['configuration3'],
-                'sylius_admin_product_from_taxon' => ['extends' => 'sylius_admin_product', 'configuration4' => 'bar'],
-                'sylius_admin_book' => ['extends' => '404'],
-                'sylius_admin_customer' => ['fields' => ['customer' => []], 'removals' => ['fields' => ['customer']]],
             ],
-            new GridConfigurationExtender(),
-            $gridConfigurationRemovalsHandler,
+            $gridFactory,
         );
     }
 
-    function it_implements_grid_provider_interface(): void
+    function it_is_a_grid_provider(): void
     {
         $this->shouldImplement(GridProviderInterface::class);
     }
 
-    function it_returns_cloned_grid_definition_by_name(Grid $firstGrid, Grid $secondGrid, Grid $thirdGrid): void
+    function it_returns_grid_definition_by_name(Grid $firstGrid, Grid $secondGrid, Grid $thirdGrid): void
     {
         $this->get('sylius_admin_tax_category')->shouldBeLike($firstGrid);
         $this->get('sylius_admin_product')->shouldBeLike($secondGrid);
         $this->get('sylius_admin_order')->shouldBeLike($thirdGrid);
-    }
-
-    function it_supports_grid_inheritance(Grid $fourthGrid): void
-    {
-        $this->get('sylius_admin_product_from_taxon')->shouldBeLike($fourthGrid);
     }
 
     function it_throws_an_exception_if_grid_does_not_exist(): void
@@ -92,17 +59,5 @@ final class ArrayGridProviderSpec extends ObjectBehavior
             ->shouldThrow(new UndefinedGridException('sylius_admin_order_item'))
             ->during('get', ['sylius_admin_order_item'])
         ;
-    }
-
-    function it_throws_an_invalid_argument_exception_when_parent_grid_is_not_found(): void
-    {
-        $this->shouldThrow(\InvalidArgumentException::class)->during('get', ['sylius_admin_book']);
-    }
-
-    function it_supports_grid_removals(
-        ArrayToDefinitionConverterInterface $converter,
-        Grid $sixthGrid,
-    ): void {
-        $this->get('sylius_admin_customer')->shouldReturn($sixthGrid);
     }
 }

--- a/tests/Application/config/sylius/grids.yaml
+++ b/tests/Application/config/sylius/grids.yaml
@@ -35,7 +35,6 @@ sylius_grid:
                 title:
                     type: string
                     label: Title
-                    sortable: ~
                 author:
                     type: string
                     label: Author

--- a/tests/Application/config/sylius/grids/book.php
+++ b/tests/Application/config/sylius/grids/book.php
@@ -49,8 +49,7 @@ return static function (GridConfig $grid) {
         ->orderBy('title', 'asc')
         ->addField(
             StringField::create('title')
-                ->setLabel('Title')
-                ->setSortable(true),
+                ->setLabel('Title'),
         )
         ->addField(
             StringField::create('author')

--- a/tests/Application/src/Grid/BookGrid.php
+++ b/tests/Application/src/Grid/BookGrid.php
@@ -74,8 +74,7 @@ final class BookGrid extends AbstractGrid implements ResourceAwareGridInterface
             ->orderBy('title', 'asc')
             ->addField(
                 StringField::create('title')
-                    ->setLabel('Title')
-                    ->setSortable(true),
+                    ->setLabel('Title'),
             )
             ->addField(
                 StringField::create('author')


### PR DESCRIPTION
This PR solves https://github.com/Sylius/SyliusGridBundle/issues/303 and refactors how a `Grid` is constructed. 

The `Grid` definition creation process is kinda duplicated in `ArrayGridProvider` and `ServiceGridProvider`.

I introduce a `GridFactory` to transform a grid configuration array into a `Grid`.

This service dispatch an event so the grid configuration array can be manipulated. Three listener have been added to reproduce what was done before and fix the sorting when the sorting key is not defined.
* `GridConfigurationExtenderListener`
* `GridConfigurationRemovalsListener`
* `GridConfigurationSortingListener`
