### PR TITLE
fix(render form): properly display default values

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,7 +43,9 @@ sylius_grid:
                         fields: { }
                     form_options:
                         type: contains # type of string filtering option, if you one to have just one
-                    default_value: ~
+                    default_value:
+                        type: contains
+                        value: example
                 enabled:
                     type: boolean # Type of filter
                     label: app.ui.enabled
@@ -53,7 +55,7 @@ sylius_grid:
                     options:
                         field: enabled
                     form_options: { }
-                    default_value: ~
+                    default_value: 'false'
                 date:
                     type: date # Type of filter
                     label: app.ui.created_at

--- a/src/Bundle/Renderer/TwigGridRenderer.php
+++ b/src/Bundle/Renderer/TwigGridRenderer.php
@@ -94,7 +94,7 @@ final class TwigGridRenderer implements GridRendererInterface
     {
         $template = $this->getFilterTemplate($filter);
 
-        $form = $this->formFactory->createNamed('criteria', FormType::class, [], [
+        $form = $this->formFactory->createNamed('criteria', FormType::class, $this->getDefaultFormData($filter), [
             'allow_extra_fields' => true,
             'csrf_protection' => false,
             'required' => false,
@@ -105,8 +105,10 @@ final class TwigGridRenderer implements GridRendererInterface
             $filter->getFormOptions(),
         );
 
-        $criteria = $gridView->getParameters()->get('criteria', []);
-        $form->submit($criteria);
+        if ($gridView->getParameters()->has('criteria')) {
+            $criteria = $gridView->getParameters()->get('criteria', []);
+            $form->submit($criteria);
+        }
 
         return $this->twig->render($template, [
             'grid' => $gridView,
@@ -131,5 +133,14 @@ final class TwigGridRenderer implements GridRendererInterface
         }
 
         return $this->filterTemplates[$type];
+    }
+
+    private function getDefaultFormData(Filter $filter): array
+    {
+        if (in_array($filter->getCriteria(), [null, '', []], true)) {
+            return [];
+        }
+
+        return [$filter->getName() => $filter->getCriteria()];
     }
 }


### PR DESCRIPTION
Fix for issue https://github.com/Sylius/SyliusGridBundle/issues/391

When the default value of a filter is changed, it is applied correctly, but the display is incorrect.

There is potentially a BC break since the default value must match the form data. For example, for the string type, both the value and the type need to be specified.