### PR TITLE
ci : update checkout action to upgrade node

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
                         symfony: "^7.0"
         steps:
             -
-                uses: actions/checkout@v2
+                uses: actions/checkout@v4
             -
                 name: Setup PHP
                 uses: shivammathur/setup-php@v2


### PR DESCRIPTION
> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

I''m not sure which branch I should target.