### PR TITLE
[FieldTypes] add vars option on DateTime & Twig field types

### DIFF
--- a/src/Bundle/Tests/Functional/GridUiTest.php
+++ b/src/Bundle/Tests/Functional/GridUiTest.php
@@ -232,6 +232,21 @@ final class GridUiTest extends ApiTestCase
     }
 
     /** @test */
+    public function it_renders_option_vars(): void
+    {
+        $this->client->request('GET', '/books/');
+
+        $data = $this->getCrawler()
+            ->filter('th.text-end')
+            ->each(
+                fn (Crawler $node): string => $node->text(),
+            )
+        ;
+
+        $this->assertSame('Currency', $data[0] ?? null);
+    }
+
+    /** @test */
     public function it_includes_all_rows_even_when_sorting_by_a_nullable_path(): void
     {
         $this->client->request('GET', '/authors/');

--- a/src/Bundle/Tests/Provider/ServiceGridProviderTest.php
+++ b/src/Bundle/Tests/Provider/ServiceGridProviderTest.php
@@ -35,6 +35,7 @@ final class ServiceGridProviderTest extends KernelTestCase
         $this->assertEquals([
             'title',
             'author',
+            'currency',
             'id',
         ], array_keys($gridDefinition->getFields()));
 

--- a/src/Bundle/spec/Builder/Field/DateTimeFieldSpec.php
+++ b/src/Bundle/spec/Builder/Field/DateTimeFieldSpec.php
@@ -31,4 +31,13 @@ final class DateTimeFieldSpec extends ObjectBehavior
         $field->shouldHaveType(FieldInterface::class);
         $field->getName()->shouldReturn('createdAt');
     }
+
+    function it_defines_var_options(): void
+    {
+        $field = $this::create('createdAt');
+        $field->setOption('vars', ['foo' => 'bar']);
+
+        $field->shouldHaveType(FieldInterface::class);
+        $field->getOptions()['vars']->shouldReturn(['foo' => 'bar']);
+    }
 }

--- a/src/Bundle/spec/Builder/Field/StringFieldSpec.php
+++ b/src/Bundle/spec/Builder/Field/StringFieldSpec.php
@@ -31,4 +31,13 @@ final class StringFieldSpec extends ObjectBehavior
         $field->shouldHaveType(FieldInterface::class);
         $field->getName()->shouldReturn('firstName');
     }
+
+    function it_defines_var_options(): void
+    {
+        $field = $this::create('firstName');
+        $field->setOption('vars', ['foo' => 'bar']);
+
+        $field->shouldHaveType(FieldInterface::class);
+        $field->getOptions()->shouldReturn(['vars' => ['foo' => 'bar']]);
+    }
 }

--- a/src/Component/FieldTypes/DatetimeFieldType.php
+++ b/src/Component/FieldTypes/DatetimeFieldType.php
@@ -55,5 +55,7 @@ final class DatetimeFieldType implements FieldTypeInterface
         $resolver->setAllowedTypes('format', 'string');
         $resolver->setDefault('timezone', $this->timezone);
         $resolver->setAllowedTypes('timezone', ['null', 'string']);
+        $resolver->setDefined('vars');
+        $resolver->setAllowedTypes('vars', 'array');
     }
 }

--- a/src/Component/FieldTypes/StringFieldType.php
+++ b/src/Component/FieldTypes/StringFieldType.php
@@ -35,5 +35,7 @@ final class StringFieldType implements FieldTypeInterface
 
     public function configureOptions(OptionsResolver $resolver): void
     {
+        $resolver->setDefined('vars');
+        $resolver->setAllowedTypes('vars', 'array');
     }
 }

--- a/src/Component/spec/FieldTypes/DatetimeFieldTypeSpec.php
+++ b/src/Component/spec/FieldTypes/DatetimeFieldTypeSpec.php
@@ -84,6 +84,8 @@ final class DatetimeFieldTypeSpec extends ObjectBehavior
         $resolver->setAllowedTypes('format', 'string')->willReturn($resolver)->shouldBeCalled();
         $resolver->setDefault('timezone', 'Europe/Warsaw')->willReturn($resolver)->shouldBeCalled();
         $resolver->setAllowedTypes('timezone', ['null', 'string'])->willReturn($resolver)->shouldBeCalled();
+        $resolver->setDefined('vars')->willReturn($resolver)->shouldBeCalled();
+        $resolver->setAllowedTypes('vars', 'array')->willReturn($resolver)->shouldBeCalled();
 
         $this->configureOptions($resolver);
     }

--- a/tests/Application/config/sylius/grids.yaml
+++ b/tests/Application/config/sylius/grids.yaml
@@ -46,6 +46,14 @@ sylius_grid:
                     label: Nationality
                     path: author.nationality.name
                     sortable: author.nationality.name
+                currency:
+                    type: string
+                    label: Currency
+                    path: price.currencyCode
+                    sortable: price.currencyCode
+                    options:
+                        vars:
+                            th_class: "text-end"
             limits: [10, 5, 15]
 
         app_author:

--- a/tests/Application/config/sylius/grids/book.php
+++ b/tests/Application/config/sylius/grids/book.php
@@ -64,6 +64,13 @@ return static function (GridConfig $grid) {
                 ->setPath('author.nationality.name')
                 ->setSortable(true, 'author.nationality.name'),
         )
+        ->addField(
+            StringField::create('currency')
+                ->setLabel('Currency')
+                ->setPath('price.currencyCode')
+                ->setSortable(true, 'price.currencyCode')
+                ->setOption('vars', ['th_class' => 'text-end']),
+        )
         ->setLimits([10, 5, 15]),
     );
 };

--- a/tests/Application/src/Grid/BookGrid.php
+++ b/tests/Application/src/Grid/BookGrid.php
@@ -89,6 +89,13 @@ final class BookGrid extends AbstractGrid implements ResourceAwareGridInterface
                     ->setPath('author.nationality.name')
                     ->setSortable(true, 'author.nationality.name'),
             )
+            ->addField(
+                StringField::create('currency')
+                    ->setLabel('Currency')
+                    ->setPath('price.currencyCode')
+                    ->setSortable(true, 'price.currencyCode')
+                    ->setOption('vars', ['th_class' => 'text-end']),
+            )
             ->addActionGroup(
                 ItemActionGroup::create(
                     ShowAction::create([

--- a/tests/Application/templates/crud/index.html.twig
+++ b/tests/Application/templates/crud/index.html.twig
@@ -10,12 +10,12 @@
     <tr>
         {% for field in definition.fields %}
             {% if field.enabled %}
-                <th class="sylius-table-column-{{ field.name }}">{{ field.label|trans }}</th>
-            {% endif %}
-            {% if definition.actionGroups.item is defined and definition.getEnabledActions('item')|length > 0 %}
-                <th class="sylius-table-column-actions">Actions</th>
+                <th class="sylius-table-column-{{ field.name }} {{ field.options.vars.th_class|default('') }}">{{ field.label|trans }}</th>
             {% endif %}
         {% endfor %}
+        {% if definition.actionGroups.item is defined and definition.getEnabledActions('item')|length > 0 %}
+            <th class="sylius-table-column-actions">Actions</th>
+        {% endif %}
     </tr>
     </thead>
     <tbody>
@@ -23,14 +23,14 @@
         <tr>
             {% for field in definition.enabledFields %}
                 <td data-test-{{ field.name }}>{{ sylius_grid_render_field(grid, field, resource) }}</td>
-                <td>
-                    {% if definition.actionGroups.item is defined and definition.getEnabledActions('item')|length > 0 %}
-                        {% for action in definition.getEnabledActions('item') %}
-                            {{ sylius_grid_render_action(grid, action, resource) }}
-                        {% endfor %}
-                    {% endif %}
-                </td>
             {% endfor %}
+            {% if definition.actionGroups.item is defined and definition.getEnabledActions('item')|length > 0 %}
+            <td>
+                {% for action in definition.getEnabledActions('item') %}
+                    {{ sylius_grid_render_action(grid, action, resource) }}
+                {% endfor %}
+            </td>
+            {% endif %}
         </tr>
     {% endfor %}
     </tbody>


### PR DESCRIPTION
Passing generic "vars" option on string & datetime fields could be useful.

```php
->addField(
      StringField::create('contractNumber')
          ->setOption('vars', ['th_class' => 'text-end'])
  )
```

When using this grid on twig rendering, you can handle these vars.
But you can also define some vars on other rendering like a CLI rendering option that could be useful too.