### PR TITLE
fix grid sorting with sorting key not defined and refactor grid definition creation

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,6 +22,7 @@
         <testsuite name="SyliusGridBundle Test Suite">
             <directory>./tests/</directory>
             <directory>./src/Bundle/Tests/</directory>
+            <directory>./src/Component/Tests/</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/src/Bundle/Provider/ServiceGridProvider.php
+++ b/src/Bundle/Provider/ServiceGridProvider.php
@@ -18,6 +18,8 @@ use Sylius\Bundle\GridBundle\Registry\GridRegistryInterface;
 use Sylius\Component\Grid\Configuration\GridConfigurationExtenderInterface;
 use Sylius\Component\Grid\Configuration\GridConfigurationRemovalsHandler;
 use Sylius\Component\Grid\Configuration\GridConfigurationRemovalsHandlerInterface;
+use Sylius\Component\Grid\Configuration\GridConfigurationSortingHandler;
+use Sylius\Component\Grid\Configuration\GridConfigurationSortingHandlerInterface;
 use Sylius\Component\Grid\Definition\ArrayToDefinitionConverterInterface;
 use Sylius\Component\Grid\Definition\Grid;
 use Sylius\Component\Grid\Exception\UndefinedGridException;
@@ -34,16 +36,20 @@ final class ServiceGridProvider implements GridProviderInterface
 
     private GridConfigurationRemovalsHandlerInterface $gridConfigurationRemovalsHandler;
 
+    private GridConfigurationSortingHandlerInterface $gridConfigurationSortingHandler;
+
     public function __construct(
         ArrayToDefinitionConverterInterface $converter,
         GridRegistryInterface $gridRegistry,
         GridConfigurationExtenderInterface $gridConfigurationExtender,
         ?GridConfigurationRemovalsHandlerInterface $gridConfigurationRemovalsHandler = null,
+        ?GridConfigurationSortingHandlerInterface $gridConfigurationSortingHandler = null,
     ) {
         $this->converter = $converter;
         $this->gridRegistry = $gridRegistry;
         $this->gridConfigurationExtender = $gridConfigurationExtender;
         $this->gridConfigurationRemovalsHandler = $gridConfigurationRemovalsHandler ?? new GridConfigurationRemovalsHandler();
+        $this->gridConfigurationSortingHandler = $gridConfigurationSortingHandler ?? new GridConfigurationSortingHandler();
     }
 
     public function get(string $code): Grid
@@ -65,6 +71,7 @@ final class ServiceGridProvider implements GridProviderInterface
         }
 
         $gridConfiguration = $this->gridConfigurationRemovalsHandler->handle($gridConfiguration);
+        $gridConfiguration = $this->gridConfigurationSortingHandler->handle($gridConfiguration);
 
         return $this->converter->convert($code, $gridConfiguration);
     }

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -43,11 +43,15 @@
         <service id="sylius.grid.configuration_removals_handler" class="Sylius\Component\Grid\Configuration\GridConfigurationRemovalsHandler"/>
         <service id="Sylius\Component\Grid\Configuration\GridConfigurationRemovalsHandlerInterface" alias="sylius.grid.configuration_removals_handler" />
 
+        <service id="sylius.grid.configuration_sorting_handler" class="Sylius\Component\Grid\Configuration\GridConfigurationSortingHandler"/>
+        <service id="Sylius\Component\Grid\Configuration\GridConfigurationSortingHandlerInterface" alias="sylius.grid.configuration_sorting_handler" />
+
         <service id="sylius.grid.array_grid_provider" class="Sylius\Component\Grid\Provider\ArrayGridProvider">
             <argument type="service" id="sylius.grid.array_to_definition_converter" />
             <argument>%sylius.grids_definitions%</argument>
             <argument type="service" id="sylius.grid.configuration_extender" />
             <argument type="service" id="sylius.grid.configuration_removals_handler" />
+            <argument type="service" id="sylius.grid.configuration_sorting_handler" />
             <tag name="sylius.grid_provider" key="array" priority="-200"/>
         </service>
         <service id="Sylius\Component\Grid\Provider\ArrayGridProvider" alias="sylius.grid.array_grid_provider" />
@@ -57,6 +61,7 @@
             <argument type="service" id="sylius.grid.grid_registry" />
             <argument type="service" id="sylius.grid.configuration_extender" />
             <argument type="service" id="sylius.grid.configuration_removals_handler" />
+            <argument type="service" id="sylius.grid.configuration_sorting_handler" />
             <tag name="sylius.grid_provider" key="service" priority="-100"/>
         </service>
         <service id="Sylius\Bundle\GridBundle\Provider\ServiceGridProvider" alias="sylius.grid.service_grid_provider" />

--- a/src/Bundle/spec/Provider/ServiceGridProviderSpec.php
+++ b/src/Bundle/spec/Provider/ServiceGridProviderSpec.php
@@ -20,6 +20,7 @@ use Sylius\Bundle\GridBundle\Provider\ServiceGridProvider;
 use Sylius\Bundle\GridBundle\Registry\GridRegistryInterface;
 use Sylius\Component\Grid\Configuration\GridConfigurationExtender;
 use Sylius\Component\Grid\Configuration\GridConfigurationRemovalsHandlerInterface;
+use Sylius\Component\Grid\Configuration\GridConfigurationSortingHandlerInterface;
 use Sylius\Component\Grid\Definition\ArrayToDefinitionConverterInterface;
 use Sylius\Component\Grid\Definition\Grid;
 use Sylius\Component\Grid\Exception\UndefinedGridException;
@@ -31,12 +32,14 @@ class ServiceGridProviderSpec extends ObjectBehavior
         ArrayToDefinitionConverterInterface $converter,
         GridRegistryInterface $gridRegistry,
         GridConfigurationRemovalsHandlerInterface $gridConfigurationRemovalsHandler,
+        GridConfigurationSortingHandlerInterface $gridConfigurationSortingHandler,
     ): void {
         $this->beConstructedWith(
             $converter,
             $gridRegistry,
             new GridConfigurationExtender(),
             $gridConfigurationRemovalsHandler,
+            $gridConfigurationSortingHandler,
         );
     }
 
@@ -53,6 +56,7 @@ class ServiceGridProviderSpec extends ObjectBehavior
     function it_gets_grids_definitions_by_code(
         ArrayToDefinitionConverterInterface $converter,
         GridConfigurationRemovalsHandlerInterface $gridConfigurationRemovalsHandler,
+        GridConfigurationSortingHandlerInterface $gridConfigurationSortingHandler,
         GridRegistryInterface $gridRegistry,
         GridInterface $bookGrid,
         Grid $gridDefinition,
@@ -62,6 +66,7 @@ class ServiceGridProviderSpec extends ObjectBehavior
 
         $converter->convert('app_book', [])->willReturn($gridDefinition);
         $gridConfigurationRemovalsHandler->handle([])->willReturn([]);
+        $gridConfigurationSortingHandler->handle([])->willReturn([]);
 
         $this->get('app_book')->shouldReturn($gridDefinition);
     }
@@ -69,6 +74,7 @@ class ServiceGridProviderSpec extends ObjectBehavior
     function it_gets_grids_definitions_by_fully_qualified_class_name(
         ArrayToDefinitionConverterInterface $converter,
         GridConfigurationRemovalsHandlerInterface $gridConfigurationRemovalsHandler,
+        GridConfigurationSortingHandlerInterface $gridConfigurationSortingHandler,
         GridRegistryInterface $gridRegistry,
         Grid $gridDefinition,
     ): void {
@@ -77,6 +83,7 @@ class ServiceGridProviderSpec extends ObjectBehavior
 
         $converter->convert('app_book', [])->willReturn($gridDefinition);
         $gridConfigurationRemovalsHandler->handle($bookGrid->toArray())->willReturn([]);
+        $gridConfigurationSortingHandler->handle([])->willReturn([]);
 
         $this->get(BookGrid::class)->shouldReturn($gridDefinition);
     }
@@ -84,6 +91,7 @@ class ServiceGridProviderSpec extends ObjectBehavior
     function it_supports_grid_inheritance(
         ArrayToDefinitionConverterInterface $converter,
         GridConfigurationRemovalsHandlerInterface $gridConfigurationRemovalsHandler,
+        GridConfigurationSortingHandlerInterface $gridConfigurationSortingHandler,
         GridRegistryInterface $gridRegistry,
         GridInterface $fooGrid,
         GridInterface $fooFightersGrid,
@@ -100,6 +108,7 @@ class ServiceGridProviderSpec extends ObjectBehavior
         $converter->convert('app_foo_fighters', ['configuration_foo' => 'foo', 'configuration_foo_fighters' => 'foo_fighters'])->willReturn($fooFightersGridDefinition);
 
         $gridConfigurationRemovalsHandler->handle(['configuration_foo' => 'foo', 'configuration_foo_fighters' => 'foo_fighters'])->willReturn(['configuration_foo' => 'foo', 'configuration_foo_fighters' => 'foo_fighters']);
+        $gridConfigurationSortingHandler->handle(['configuration_foo' => 'foo', 'configuration_foo_fighters' => 'foo_fighters'])->willReturn(['configuration_foo' => 'foo', 'configuration_foo_fighters' => 'foo_fighters']);
 
         $this->get('app_foo_fighters')->shouldReturn($fooFightersGridDefinition);
     }
@@ -128,6 +137,7 @@ class ServiceGridProviderSpec extends ObjectBehavior
         ArrayToDefinitionConverterInterface $converter,
         GridRegistryInterface $gridRegistry,
         GridConfigurationRemovalsHandlerInterface $gridConfigurationRemovalsHandler,
+        GridConfigurationSortingHandlerInterface $gridConfigurationSortingHandler,
         GridInterface $fooGrid,
         Grid $fooGridDefinition,
     ): void {
@@ -149,8 +159,77 @@ class ServiceGridProviderSpec extends ObjectBehavior
             'fields' => [],
         ]);
 
+        $gridConfigurationSortingHandler->handle([
+            'fields' => [],
+        ])->willReturn([
+            'fields' => [],
+        ]);
+
         $converter->convert('app_foo', [
             'fields' => [],
+        ])->willReturn($fooGridDefinition);
+
+        $this->get('app_foo')->shouldReturn($fooGridDefinition);
+    }
+
+    function it_makes_fields_sortable_if_sorting_is_enabled_for_it(
+        ArrayToDefinitionConverterInterface $converter,
+        GridRegistryInterface $gridRegistry,
+        GridConfigurationRemovalsHandlerInterface $gridConfigurationRemovalsHandler,
+        GridConfigurationSortingHandlerInterface $gridConfigurationSortingHandler,
+        GridInterface $fooGrid,
+        Grid $fooGridDefinition,
+    ): void {
+        $gridRegistry->getGrid('app_foo')->willReturn($fooGrid);
+
+        $fooGrid->toArray()->willReturn([
+            'fields' => [
+                'title' => [],
+            ],
+            'sorting' => [
+                'title' => 'asc',
+            ],
+        ]);
+
+        $gridConfigurationRemovalsHandler->handle([
+            'fields' => [
+                'title' => [],
+            ],
+            'sorting' => [
+                'title' => 'asc',
+            ],
+        ])->willReturn([
+            'fields' => [
+                'title' => [],
+            ],
+            'sorting' => [
+                'title' => 'asc',
+            ],
+        ]);
+
+        $gridConfigurationSortingHandler->handle([
+            'fields' => [
+                'title' => [],
+            ],
+            'sorting' => [
+                'title' => 'asc',
+            ],
+        ])->willReturn([
+            'fields' => [
+                'title' => ['sortable' => true],
+            ],
+            'sorting' => [
+                'title' => 'asc',
+            ],
+        ]);
+
+        $converter->convert('app_foo', [
+            'fields' => [
+                'title' => ['sortable' => true],
+            ],
+            'sorting' => [
+                'title' => 'asc',
+            ],
         ])->willReturn($fooGridDefinition);
 
         $this->get('app_foo')->shouldReturn($fooGridDefinition);

--- a/src/Component/Configuration/GridConfigurationSortingHandler.php
+++ b/src/Component/Configuration/GridConfigurationSortingHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Configuration;
+
+use Webmozart\Assert\Assert;
+
+final class GridConfigurationSortingHandler implements GridConfigurationSortingHandlerInterface
+{
+    public function handle(array $gridConfiguration): array
+    {
+        if (false === isset($gridConfiguration['sorting'])) {
+            return $gridConfiguration;
+        }
+
+        foreach ($gridConfiguration['sorting'] as $sorting => $order) {
+            Assert::keyExists($gridConfiguration['fields'] ?? [], $sorting);
+
+            $gridConfiguration['fields'][$sorting]['sortable'] = true;
+        }
+
+        return $gridConfiguration;
+    }
+}

--- a/src/Component/Configuration/GridConfigurationSortingHandlerInterface.php
+++ b/src/Component/Configuration/GridConfigurationSortingHandlerInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Configuration;
+
+interface GridConfigurationSortingHandlerInterface
+{
+    public function handle(array $gridConfiguration): array;
+}

--- a/src/Component/Provider/ArrayGridProvider.php
+++ b/src/Component/Provider/ArrayGridProvider.php
@@ -17,6 +17,8 @@ use Sylius\Component\Grid\Configuration\GridConfigurationExtender;
 use Sylius\Component\Grid\Configuration\GridConfigurationExtenderInterface;
 use Sylius\Component\Grid\Configuration\GridConfigurationRemovalsHandler;
 use Sylius\Component\Grid\Configuration\GridConfigurationRemovalsHandlerInterface;
+use Sylius\Component\Grid\Configuration\GridConfigurationSortingHandler;
+use Sylius\Component\Grid\Configuration\GridConfigurationSortingHandlerInterface;
 use Sylius\Component\Grid\Definition\ArrayToDefinitionConverterInterface;
 use Sylius\Component\Grid\Definition\Grid;
 use Sylius\Component\Grid\Exception\UndefinedGridException;
@@ -30,6 +32,8 @@ final class ArrayGridProvider implements GridProviderInterface
 
     private GridConfigurationRemovalsHandlerInterface $gridConfigurationRemovalsHandler;
 
+    private GridConfigurationSortingHandlerInterface $gridConfigurationSortingHandler;
+
     /** @var array[] */
     private array $gridConfigurations;
 
@@ -38,11 +42,13 @@ final class ArrayGridProvider implements GridProviderInterface
         array $gridConfigurations,
         ?GridConfigurationExtenderInterface $gridConfigurationExtender = null,
         ?GridConfigurationRemovalsHandlerInterface $gridConfigurationRemovalsHandler = null,
+        ?GridConfigurationSortingHandlerInterface $gridConfigurationSortingHandler = null,
     ) {
         $this->converter = $converter;
         $this->gridConfigurations = $gridConfigurations;
         $this->gridConfigurationExtender = $gridConfigurationExtender ?? new GridConfigurationExtender();
         $this->gridConfigurationRemovalsHandler = $gridConfigurationRemovalsHandler ?? new GridConfigurationRemovalsHandler();
+        $this->gridConfigurationSortingHandler = $gridConfigurationSortingHandler ?? new GridConfigurationSortingHandler();
     }
 
     public function get(string $code): Grid
@@ -62,6 +68,7 @@ final class ArrayGridProvider implements GridProviderInterface
         }
 
         $gridConfiguration = $this->gridConfigurationRemovalsHandler->handle($gridConfiguration);
+        $gridConfiguration = $this->gridConfigurationSortingHandler->handle($gridConfiguration);
 
         return $this->converter->convert($code, $gridConfiguration);
     }

--- a/src/Component/Tests/Unit/Configuration/GridConfigurationSortingHandlerTest.php
+++ b/src/Component/Tests/Unit/Configuration/GridConfigurationSortingHandlerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Tests\Unit\Configuration;
+
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Grid\Configuration\GridConfigurationSortingHandler;
+
+final class GridConfigurationSortingHandlerTest extends TestCase
+{
+    public function testHandle(): void
+    {
+        $gridConfiguration = [
+            'fields' => [
+                'title' => [],
+                'author' => ['sortable' => false],
+                'price' => ['sortable' => true],
+            ],
+            'sorting' => [
+                'title' => 'asc',
+                'author' => 'asc',
+                'price' => 'asc',
+            ],
+        ];
+
+        $this->assertEquals([
+            'fields' => [
+                'title' => ['sortable' => true],
+                'author' => ['sortable' => true],
+                'price' => ['sortable' => true],
+            ],
+            'sorting' => [
+                'title' => 'asc',
+                'author' => 'asc',
+                'price' => 'asc',
+            ],
+        ], (new GridConfigurationSortingHandler())->handle($gridConfiguration));
+    }
+}

--- a/src/Component/spec/Provider/ArrayGridProviderSpec.php
+++ b/src/Component/spec/Provider/ArrayGridProviderSpec.php
@@ -16,6 +16,7 @@ namespace spec\Sylius\Component\Grid\Provider;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Grid\Configuration\GridConfigurationExtender;
 use Sylius\Component\Grid\Configuration\GridConfigurationRemovalsHandlerInterface;
+use Sylius\Component\Grid\Configuration\GridConfigurationSortingHandlerInterface;
 use Sylius\Component\Grid\Definition\ArrayToDefinitionConverterInterface;
 use Sylius\Component\Grid\Definition\Grid;
 use Sylius\Component\Grid\Exception\UndefinedGridException;
@@ -26,12 +27,14 @@ final class ArrayGridProviderSpec extends ObjectBehavior
     function let(
         ArrayToDefinitionConverterInterface $converter,
         GridConfigurationRemovalsHandlerInterface $gridConfigurationRemovalsHandler,
+        GridConfigurationSortingHandlerInterface $gridConfigurationSortingHandler,
         Grid $firstGrid,
         Grid $secondGrid,
         Grid $thirdGrid,
         Grid $fourthGrid,
         Grid $fifthGrid,
         Grid $sixthGrid,
+        Grid $seventhGrid,
     ): void {
         $converter->convert('sylius_admin_tax_category', ['configuration1'])->willReturn($firstGrid);
         $converter->convert('sylius_admin_product', ['configuration2' => 'foo'])->willReturn($secondGrid);
@@ -39,12 +42,24 @@ final class ArrayGridProviderSpec extends ObjectBehavior
         $converter->convert('sylius_admin_product_from_taxon', ['configuration4' => 'bar', 'configuration2' => 'foo'])->willReturn($fourthGrid);
         $converter->convert('sylius_admin_book', ['extends' => '404'])->willReturn($fifthGrid);
         $converter->convert('sylius_admin_customer', ['fields' => []])->willReturn($sixthGrid);
+        $converter->convert('sylius_admin_book_per_author', [
+        'fields' => [
+            'title' => ['sortable' => true],
+        ],
+        'sorting' => [
+            'title' => 'asc',
+        ]])->willReturn($seventhGrid);
 
         $gridConfigurationRemovalsHandler->handle(['configuration1'])->willReturn(['configuration1']);
+        $gridConfigurationSortingHandler->handle(['configuration1'])->willReturn(['configuration1']);
         $gridConfigurationRemovalsHandler->handle(['configuration2' => 'foo'])->willReturn(['configuration2' => 'foo']);
+        $gridConfigurationSortingHandler->handle(['configuration2' => 'foo'])->willReturn(['configuration2' => 'foo']);
         $gridConfigurationRemovalsHandler->handle(['configuration3'])->willReturn(['configuration3']);
+        $gridConfigurationSortingHandler->handle(['configuration3'])->willReturn(['configuration3']);
         $gridConfigurationRemovalsHandler->handle(['configuration4' => 'bar', 'configuration2' => 'foo'])->willReturn(['configuration4' => 'bar', 'configuration2' => 'foo']);
+        $gridConfigurationSortingHandler->handle(['configuration4' => 'bar', 'configuration2' => 'foo'])->willReturn(['configuration4' => 'bar', 'configuration2' => 'foo']);
         $gridConfigurationRemovalsHandler->handle(['extends' => '404'])->willReturn(['extends' => '404']);
+        $gridConfigurationSortingHandler->handle(['extends' => '404'])->willReturn(['extends' => '404']);
         $gridConfigurationRemovalsHandler->handle([
             'fields' => ['customer' => []],
             'removals' => [
@@ -52,6 +67,37 @@ final class ArrayGridProviderSpec extends ObjectBehavior
             ],
         ])->willReturn([
             'fields' => [],
+        ]);
+        $gridConfigurationSortingHandler->handle(['fields' => []])->willReturn(['fields' => []]);
+        $gridConfigurationRemovalsHandler->handle([
+            'fields' => [
+                'title' => [],
+            ],
+            'sorting' => [
+                'title' => 'asc',
+            ],
+        ])->willReturn([
+            'fields' => [
+                'title' => [],
+            ],
+            'sorting' => [
+                'title' => 'asc',
+            ],
+        ]);
+        $gridConfigurationSortingHandler->handle([
+            'fields' => [
+                'title' => [],
+            ],
+            'sorting' => [
+                'title' => 'asc',
+            ],
+        ])->willReturn([
+            'fields' => [
+                'title' => ['sortable' => true],
+            ],
+            'sorting' => [
+                'title' => 'asc',
+            ],
         ]);
 
         $this->beConstructedWith(
@@ -63,9 +109,18 @@ final class ArrayGridProviderSpec extends ObjectBehavior
                 'sylius_admin_product_from_taxon' => ['extends' => 'sylius_admin_product', 'configuration4' => 'bar'],
                 'sylius_admin_book' => ['extends' => '404'],
                 'sylius_admin_customer' => ['fields' => ['customer' => []], 'removals' => ['fields' => ['customer']]],
+                'sylius_admin_book_per_author' => [
+                    'fields' => [
+                        'title' => [],
+                    ],
+                    'sorting' => [
+                        'title' => 'asc',
+                    ],
+                ],
             ],
             new GridConfigurationExtender(),
             $gridConfigurationRemovalsHandler,
+            $gridConfigurationSortingHandler,
         );
     }
 
@@ -104,5 +159,12 @@ final class ArrayGridProviderSpec extends ObjectBehavior
         Grid $sixthGrid,
     ): void {
         $this->get('sylius_admin_customer')->shouldReturn($sixthGrid);
+    }
+
+    function it_makes_fields_sortable_if_sorting_is_enabled_for_it(
+        ArrayToDefinitionConverterInterface $converter,
+        Grid $seventhGrid,
+    ): void {
+        $this->get('sylius_admin_book_per_author')->shouldReturn($seventhGrid);
     }
 }

--- a/tests/Application/config/sylius/grids.yaml
+++ b/tests/Application/config/sylius/grids.yaml
@@ -37,7 +37,6 @@ sylius_grid:
                     options:
                         callable: "callable:strtoupper"
                     label: Title
-                    sortable: ~
                 author:
                     type: string
                     label: Author

--- a/tests/Application/config/sylius/grids/book.php
+++ b/tests/Application/config/sylius/grids/book.php
@@ -50,8 +50,7 @@ return static function (GridConfig $grid) {
         ->orderBy('title', 'asc')
         ->addField(
             CallableField::create('title', 'strtoupper')
-                ->setLabel('Title')
-                ->setSortable(true),
+                ->setLabel('Title'),
         )
         ->addField(
             StringField::create('author')

--- a/tests/Application/src/Grid/BookGrid.php
+++ b/tests/Application/src/Grid/BookGrid.php
@@ -75,8 +75,7 @@ final class BookGrid extends AbstractGrid implements ResourceAwareGridInterface
             ->orderBy('title', 'asc')
             ->addField(
                 CallableField::create('title', 'strtoupper')
-                    ->setLabel('Title')
-                    ->setSortable(true),
+                    ->setLabel('Title'),
             )
             ->addField(
                 StringField::create('author')


### PR DESCRIPTION
This PR fixes issue #303  without refactoring the code as previously done in the PR #354

While refactoring would be nice, it seems complex without introducing BC breaks. That's why, this PR focuses on fixing the bug only