### PR TITLE
update CallableFieldType to work with services

### DIFF
--- a/src/Bundle/Builder/Field/CallableField.php
+++ b/src/Bundle/Builder/Field/CallableField.php
@@ -22,4 +22,18 @@ final class CallableField
             ->setOption('htmlspecialchars', $htmlspecialchars)
         ;
     }
+
+    public static function createForService(string $name, string $service, ?string $method = null, bool $htmlspecialchars = true): FieldInterface
+    {
+        $field = Field::create($name, 'callable')
+            ->setOption('service', $service)
+            ->setOption('htmlspecialchars', $htmlspecialchars)
+        ;
+
+        if ($method !== null) {
+            $field->setOption('method', $method);
+        }
+
+        return $field;
+    }
 }

--- a/src/Bundle/DependencyInjection/SyliusGridExtension.php
+++ b/src/Bundle/DependencyInjection/SyliusGridExtension.php
@@ -16,6 +16,7 @@ namespace Sylius\Bundle\GridBundle\DependencyInjection;
 use Sylius\Bundle\CurrencyBundle\SyliusCurrencyBundle;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 use Sylius\Bundle\GridBundle\SyliusGridBundle;
+use Sylius\Component\Grid\Annotation\AsGridFieldCallableService;
 use Sylius\Component\Grid\Attribute\AsFilter;
 use Sylius\Component\Grid\Data\DataProviderInterface;
 use Sylius\Component\Grid\Filtering\ConfigurableFilterInterface;
@@ -85,6 +86,13 @@ final class SyliusGridExtension extends Extension
         $container->registerForAutoconfiguration(DataProviderInterface::class)
             ->addTag('sylius.grid_data_provider')
         ;
+
+        $container->registerAttributeForAutoconfiguration(
+            AsGridFieldCallableService::class,
+            static function (ChildDefinition $definition, AsGridFieldCallableService $attribute, \Reflector $reflector): void {
+                $definition->addTag('sylius.grid_field_callable_service');
+            },
+        );
     }
 
     public function getConfiguration(array $config, ContainerBuilder $container): Configuration

--- a/src/Bundle/Resources/config/services/field_types.xml
+++ b/src/Bundle/Resources/config/services/field_types.xml
@@ -17,6 +17,7 @@
 
         <service id="sylius.grid_field.callable" class="Sylius\Component\Grid\FieldTypes\CallableFieldType">
             <argument type="service" id="sylius.grid.data_extractor" />
+            <argument type="tagged_locator" tag="sylius.grid_field_callable_service" />
             <tag name="sylius.grid_field" type="callable" />
         </service>
         <service id="Sylius\Component\Grid\FieldTypes\CallableFieldType" alias="sylius.grid_field.callable" />

--- a/src/Bundle/Tests/Functional/GridUiTest.php
+++ b/src/Bundle/Tests/Functional/GridUiTest.php
@@ -56,6 +56,19 @@ final class GridUiTest extends ApiTestCase
     }
 
     /** @test */
+    public function it_shows_authors_nationalities(): void
+    {
+        $this->client->request('GET', '/authors/?limit=100');
+
+        $nationalities = $this->getAuthorNationalitiesFromResponse();
+
+        $this->assertCount(3, array_unique($nationalities));
+        $this->assertContains('US', $nationalities);
+        $this->assertContains('EN', $nationalities);
+        $this->assertContains('', $nationalities);
+    }
+
+    /** @test */
     public function it_sorts_authors_by_name_ascending_by_default(): void
     {
         $this->client->request('GET', '/authors/?limit=100');
@@ -308,6 +321,16 @@ final class GridUiTest extends ApiTestCase
     {
         return $this->getCrawler()
             ->filter('[data-test-id]')
+            ->each(
+                fn (Crawler $node): string => $node->text(),
+            );
+    }
+
+    /** @return string[] */
+    private function getAuthorNationalitiesFromResponse(): array
+    {
+        return $this->getCrawler()
+            ->filter('[data-test-nationality]')
             ->each(
                 fn (Crawler $node): string => $node->text(),
             );

--- a/src/Component/Annotation/AsGridFieldCallableService.php
+++ b/src/Component/Annotation/AsGridFieldCallableService.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Annotation;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class AsGridFieldCallableService
+{
+}

--- a/src/Component/FieldTypes/CallableFieldType.php
+++ b/src/Component/FieldTypes/CallableFieldType.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Grid\FieldTypes;
 
+use Psr\Container\ContainerInterface;
 use Sylius\Component\Grid\DataExtractor\DataExtractorInterface;
 use Sylius\Component\Grid\Definition\Field;
 use Sylius\Component\Grid\Exception\UnexpectedValueException;
@@ -20,14 +21,20 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class CallableFieldType implements FieldTypeInterface
 {
-    public function __construct(private DataExtractorInterface $dataExtractor)
-    {
+    public function __construct(
+        private DataExtractorInterface $dataExtractor,
+        private ContainerInterface $locator,
+    ) {
     }
 
     public function render(Field $field, $data, array $options): string
     {
+        if (isset($options['callable']) === isset($options['service'])) {
+            throw new \RuntimeException('Exactly one of the "callable" or "service" options must be defined.');
+        }
+
         $value = $this->dataExtractor->get($field, $data);
-        $value = call_user_func($options['callable'], $value);
+        $value = call_user_func($this->getCallable($options), $value);
 
         try {
             $value = (string) $value;
@@ -46,10 +53,44 @@ final class CallableFieldType implements FieldTypeInterface
         return $value;
     }
 
+    private function getCallable(array $options): callable
+    {
+        if (isset($options['callable'])) {
+            return $options['callable'];
+        }
+
+        if (!$this->locator->has($options['service'])) {
+            throw new \RuntimeException(sprintf('Service "%s" not found, make sure it is tagged with "sylius.grid_field_callable_service".', $options['service']));
+        }
+
+        $service = $this->locator->get($options['service']);
+        if (isset($options['method'])) {
+            $callable = [$service, $options['method']];
+
+            if (!is_callable($callable)) {
+                throw new \RuntimeException(sprintf('The method "%s" is not callable on service "%s".', $options['method'], $options['service']));
+            }
+
+            return $callable;
+        }
+
+        if (!is_callable($service)) {
+            throw new \RuntimeException(sprintf('The service "%s" is not callable.', $options['service']));
+        }
+
+        return $service;
+    }
+
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $resolver->setRequired('callable');
+        $resolver->setDefined('callable');
         $resolver->setAllowedTypes('callable', 'callable');
+
+        $resolver->setDefined('service');
+        $resolver->setAllowedTypes('service', 'string');
+
+        $resolver->setDefined('method');
+        $resolver->setAllowedTypes('method', 'string');
 
         $resolver->setDefault('htmlspecialchars', true);
         $resolver->setAllowedTypes('htmlspecialchars', 'bool');

--- a/src/Component/spec/FieldTypes/CallableFieldTypeSpec.php
+++ b/src/Component/spec/FieldTypes/CallableFieldTypeSpec.php
@@ -18,12 +18,30 @@ use Sylius\Component\Grid\DataExtractor\DataExtractorInterface;
 use Sylius\Component\Grid\Definition\Field;
 use Sylius\Component\Grid\Exception\UnexpectedValueException;
 use Sylius\Component\Grid\FieldTypes\FieldTypeInterface;
+use Symfony\Contracts\Service\ServiceLocatorTrait;
+use Symfony\Contracts\Service\ServiceProviderInterface;
 
 final class CallableFieldTypeSpec extends ObjectBehavior
 {
     function let(DataExtractorInterface $dataExtractor): void
     {
-        $this->beConstructedWith($dataExtractor);
+        $this->beConstructedWith(
+            $dataExtractor,
+            new class(['my_service' => fn () => new class() {
+                public function __invoke(string $value): string
+                {
+                    return strtoupper($value);
+                }
+
+                public function concatenate(array $value): string
+                {
+                    return implode(', ', $value);
+                }
+            },
+            ]) implements ServiceProviderInterface {
+                use ServiceLocatorTrait;
+            },
+        );
     }
 
     function it_is_a_grid_field_type(): void
@@ -79,6 +97,31 @@ final class CallableFieldTypeSpec extends ObjectBehavior
         ])->shouldReturn('bar');
     }
 
+    function it_uses_data_extractor_to_obtain_data_and_passes_it_to_a_service(
+        DataExtractorInterface $dataExtractor,
+        Field $field,
+    ): void {
+        $dataExtractor->get($field, ['foo' => 'bar'])->willReturn('bar');
+
+        $this->render($field, ['foo' => 'bar'], [
+            'service' => 'my_service',
+            'htmlspecialchars' => true,
+        ])->shouldReturn('BAR');
+    }
+
+    function it_uses_data_extractor_to_obtain_data_and_passes_it_to_a_service_and_method(
+        DataExtractorInterface $dataExtractor,
+        Field $field,
+    ): void {
+        $dataExtractor->get($field, ['foo' => ['foo', 'bar', 'foobar']])->willReturn(['foo', 'bar', 'foobar']);
+
+        $this->render($field, ['foo' => ['foo', 'bar', 'foobar']], [
+            'service' => 'my_service',
+            'method' => 'concatenate',
+            'htmlspecialchars' => true,
+        ])->shouldReturn('foo, bar, foobar');
+    }
+
     function it_throws_an_exception_when_a_callable_return_value_cannot_be_casted_to_string(
         DataExtractorInterface $dataExtractor,
         Field $field,
@@ -94,6 +137,35 @@ final class CallableFieldTypeSpec extends ObjectBehavior
                 [
                     'callable' => fn () => new \stdclass(),
                     'htmlspecialchars' => true,
+                ],
+            ]);
+    }
+
+    function it_throws_an_exception_when_neither_callable_nor_service_options_are_defined(
+        DataExtractorInterface $dataExtractor,
+        Field $field,
+    ): void {
+        $this
+            ->shouldThrow(\RuntimeException::class)
+            ->during('render', [
+                $field,
+                ['foo' => 'bar'],
+                [],
+            ]);
+    }
+
+    function it_throws_an_exception_when_both_callable_and_service_options_are_defined(
+        DataExtractorInterface $dataExtractor,
+        Field $field,
+    ): void {
+        $this
+            ->shouldThrow(\RuntimeException::class)
+            ->during('render', [
+                $field,
+                ['foo' => 'bar'],
+                [
+                    'callable' => fn () => new \stdclass(),
+                    'service' => 'my_service',
                 ],
             ]);
     }

--- a/tests/Application/config/services.yaml
+++ b/tests/Application/config/services.yaml
@@ -30,3 +30,5 @@ services:
 
     App\BoardGameBlog\:
         resource: '../src/BoardGameBlog'
+
+    App\Helper\GridHelper: ~

--- a/tests/Application/config/sylius/grids.yaml
+++ b/tests/Application/config/sylius/grids.yaml
@@ -79,11 +79,14 @@ sylius_grid:
                     label: Name
                     sortable: ~
                 nationality:
-                    type: string
+                    type: callable
+                    options:
+                        service: 'App\Helper\GridHelper'
+                        method: 'formatNationality'
                     label: Name
                     sortable: nationality.name
                     path: nationality
-            limits: [10, 5, 15]
+            limits: [10, 5, 15, 100]
 
         app_book_by_american_authors:
             driver:

--- a/tests/Application/config/sylius/grids/author.php
+++ b/tests/Application/config/sylius/grids/author.php
@@ -32,10 +32,10 @@ return static function (GridConfig $grid) {
                     ->setSortable(true),
             )
             ->addField(
-                StringField::create('nationality')
+                CallableField::createForService('nationality', \App\Helper\GridHelper::class)
                     ->setLabel('Nationality')
                     ->setSortable(true, 'nationality.name'),
             )
-            ->setLimits([10, 5, 15]),
+            ->setLimits([10, 5, 15, 100]),
     );
 };

--- a/tests/Application/src/Grid/AuthorGrid.php
+++ b/tests/Application/src/Grid/AuthorGrid.php
@@ -55,12 +55,12 @@ final class AuthorGrid extends AbstractGrid implements ResourceAwareGridInterfac
                     ->setSortable(true),
             )
             ->addField(
-                StringField::create('nationality')
+                CallableField::createForService('nationality', \App\Helper\GridHelper::class, 'formatNationality')
                     ->setLabel('Name')
                     ->setPath('nationality')
                     ->setSortable(true, 'nationality.name'),
             )
-            ->setLimits([10, 5, 15])
+            ->setLimits([10, 5, 15, 100])
         ;
     }
 }

--- a/tests/Application/src/Helper/GridHelper.php
+++ b/tests/Application/src/Helper/GridHelper.php
@@ -13,8 +13,25 @@ declare(strict_types=1);
 
 namespace App\Helper;
 
+use Sylius\Component\Grid\Annotation\AsGridFieldCallableService;
+
+#[AsGridFieldCallableService]
 final class GridHelper
 {
+    public function __invoke(?string $value): string
+    {
+        return $this->formatNationality($value);
+    }
+
+    public function formatNationality(?string $value): string
+    {
+        return match ($value) {
+            'English' => 'EN',
+            'American' => 'US',
+            null => '',
+        };
+    }
+
     public static function addHashPrefix(string $value): string
     {
         return '#' . $value;


### PR DESCRIPTION
Uptdate the CallableFieldType so it can be used with services.

Available services are the one tagged with `sylius.grid_field_callable_service`.

The documentation for this can be found in the second commit of this PR https://github.com/Sylius/Stack/pull/245