### PR TITLE
Configure template via the AsFilter attribute

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "symfony/http-kernel": "^5.4 || ^6.4 || ^7.0",
         "symfony/options-resolver": "^5.4 || ^6.4 || ^7.0",
         "symfony/property-access": "^5.4 || ^6.4 || ^7.0",
+        "symfony/validator": "^5.4 || ^6.4 || ^7.0",
         "webmozart/assert": "^1.9"
     },
     "replace": {

--- a/src/Bundle/DependencyInjection/Compiler/RegisterFiltersPass.php
+++ b/src/Bundle/DependencyInjection/Compiler/RegisterFiltersPass.php
@@ -47,11 +47,12 @@ final class RegisterFiltersPass implements CompilerPassInterface
                 $formType = $class::getFormType();
             }
 
-            $this->registerFilter($filterRegistry, $formTypeRegistry, $id, $attributes, $type, $formType);
+            $this->registerFilter($container, $filterRegistry, $formTypeRegistry, $id, $attributes, $type, $formType);
         }
     }
 
     private function registerFilter(
+        ContainerBuilder $container,
         Definition $filterRegistry,
         Definition $formTypeRegistry,
         string $id,
@@ -60,16 +61,34 @@ final class RegisterFiltersPass implements CompilerPassInterface
         ?string $formType = null,
     ): void {
         foreach ($attributes as $attribute) {
-            if (null === $type && null === ($attribute['type'] ?? null)) {
+            $template = $attribute['template'] ?? null;
+
+            $filterType = $type ?? $attribute['type'] ?? null;
+            $filterFormType = $formType ?? $attribute['form_type'] ?? null;
+
+            if (null === $filterType) {
                 throw new \InvalidArgumentException(sprintf('Tagged grid filters needs to have "type" attribute or implements "%s".', TypeAwareFilterInterface::class));
             }
 
-            if (null === $formType && null === ($attribute['form_type'] ?? null)) {
+            if (null === $filterFormType) {
                 throw new \InvalidArgumentException(sprintf('Tagged grid filters needs to have "form_type" attribute or implements "%s".', FormTypeAwareFilterInterface::class));
             }
 
-            $filterRegistry->addMethodCall('register', [$type ?? $attribute['type'], new Reference($id)]);
-            $formTypeRegistry->addMethodCall('add', [$type ?? $attribute['type'], 'default', $formType ?? $attribute['form_type']]);
+            $filterRegistry->addMethodCall('register', [$filterType, new Reference($id)]);
+            $formTypeRegistry->addMethodCall('add', [$filterType, 'default', $filterFormType]);
+
+            if (null !== $template) {
+                $this->registerFilterTemplate($container, $filterType, $template);
+            }
         }
+    }
+
+    private function registerFilterTemplate(ContainerBuilder $container, string $filterType, string $template): void
+    {
+        /** @var array<string, string> $filtersConfig */
+        $filtersConfig = $container->hasParameter('sylius.grid.templates.filter') ? $container->getParameter('sylius.grid.templates.filter') : [];
+
+        $filtersConfig[$filterType] = $template;
+        $container->setParameter('sylius.grid.templates.filter', $filtersConfig);
     }
 }

--- a/src/Bundle/DependencyInjection/SyliusGridExtension.php
+++ b/src/Bundle/DependencyInjection/SyliusGridExtension.php
@@ -73,6 +73,7 @@ final class SyliusGridExtension extends Extension
                 $definition->addTag(AsFilter::SERVICE_TAG, [
                     'type' => $attribute->type ?? $reflector->getName(),
                     'form_type' => $attribute->formType,
+                    'template' => $attribute->template,
                 ]);
             },
         );

--- a/src/Bundle/Tests/DependencyInjection/Compiler/RegisterFiltersPassTest.php
+++ b/src/Bundle/Tests/DependencyInjection/Compiler/RegisterFiltersPassTest.php
@@ -70,6 +70,34 @@ final class RegisterFiltersPassTest extends AbstractCompilerPassTestCase
         }
     }
 
+    /** @test */
+    public function it_registers_filter_templates(): void
+    {
+        $tags = [
+            ['type' => 'foo', 'form_type' => 'foo_type'],
+            ['type' => 'bar', 'form_type' => 'bar_type', 'template' => 'bar.html.twig'],
+            ['type' => 'baz', 'form_type' => 'baz_type', 'template' => 'baz.html.twig'],
+        ];
+        $filterService = $this->registerService('app.grid_filter.foo', Foo::class);
+        $this->container->setParameter('sylius.grid.templates.filter', []);
+
+        foreach ($tags as $tag) {
+            $filterService->addTag('sylius.grid_filter', $tag);
+        }
+        $this->registerService('sylius.registry.grid_filter', ServiceRegistry::class);
+        $this->registerService(
+            'sylius.form_registry.grid_filter',
+            ServiceRegistry::class,
+        );
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasParameter('sylius.grid.templates.filter', [
+            'bar' => 'bar.html.twig',
+            'baz' => 'baz.html.twig',
+        ]);
+    }
+
     /**
      * @test
      */

--- a/src/Component/Attribute/AsFilter.php
+++ b/src/Component/Attribute/AsFilter.php
@@ -24,6 +24,7 @@ final class AsFilter
     public function __construct(
         public readonly string $formType,
         public readonly ?string $type = null,
+        public readonly ?string $template = null,
     ) {
     }
 }

--- a/tests/Application/config/packages/sylius_grid.yaml
+++ b/tests/Application/config/packages/sylius_grid.yaml
@@ -8,3 +8,8 @@ sylius_grid:
         bulk_action:
             apply_transition: 'grid/bulk_action/apply_transition.html.twig'
             delete: 'grid/bulk_action/delete.html.twig'
+        filter:
+            entity: 'grid/filter/entity.html.twig'
+            select: 'grid/filter/select.html.twig'
+            string: 'grid/filter/string.html.twig'
+            nationality: 'grid/filter/entity.html.twig'

--- a/tests/Application/config/sylius/grids/book.php
+++ b/tests/Application/config/sylius/grids/book.php
@@ -34,7 +34,7 @@ return static function (GridConfig $grid) {
             ['author.nationality'],
         ))
         ->addFilter(AttributeNationalityFilter::create(
-            AttributeNationalityFilter::class,
+            'attribute_nationality',
             null,
             ['author.nationality'],
         ))

--- a/tests/Application/src/Entity/Author.php
+++ b/tests/Application/src/Entity/Author.php
@@ -85,4 +85,9 @@ class Author implements ResourceInterface
     {
         return $this->books;
     }
+
+    public function __toString(): string
+    {
+        return $this->name ?? '';
+    }
 }

--- a/tests/Application/src/Filter/AttributeNationalityFilter.php
+++ b/tests/Application/src/Filter/AttributeNationalityFilter.php
@@ -21,6 +21,7 @@ use Sylius\Component\Grid\Filtering\FilterInterface;
 
 #[AsFilter(
     formType: NationalityFilterType::class,
+    template: 'grid/filter/entity.html.twig',
 )]
 final class AttributeNationalityFilter implements FilterInterface
 {

--- a/tests/Application/src/Grid/Type/NationalityFilterType.php
+++ b/tests/Application/src/Grid/Type/NationalityFilterType.php
@@ -28,7 +28,7 @@ final class NationalityFilterType extends FormType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'data_class' => Nationality::class,
+            'class' => Nationality::class,
         ]);
     }
 }

--- a/tests/Application/templates/crud/index.html.twig
+++ b/tests/Application/templates/crud/index.html.twig
@@ -5,6 +5,22 @@
 {% set grid = resources %}
 {% set definition = grid.definition %}
 
+{% if definition.enabledFilters is not empty %}
+    <div>
+        {% set content %}
+            <form method="get" novalidate>
+                <div class="sylius-filters">
+                    {% for filter in resources.definition.enabledFilters|filter(filter => filter.enabled) %}
+                        <div class="sylius-filters__item">
+                            {{ sylius_grid_render_filter(resources, filter) }}
+                        </div>
+                    {% endfor %}
+                </div>
+            </form>
+        {% endset %}
+    </div>
+{% endif %}
+
 <table>
     <thead>
     <tr>

--- a/tests/Application/templates/grid/filter/entity.html.twig
+++ b/tests/Application/templates/grid/filter/entity.html.twig
@@ -1,0 +1,1 @@
+{{ form_row(form, {'label': filter.label}) }}

--- a/tests/Application/templates/grid/filter/select.html.twig
+++ b/tests/Application/templates/grid/filter/select.html.twig
@@ -1,0 +1,1 @@
+{{ form_row(form, {'label': filter.label}) }}

--- a/tests/Application/templates/grid/filter/string.html.twig
+++ b/tests/Application/templates/grid/filter/string.html.twig
@@ -1,0 +1,4 @@
+{% if form.type is defined %}
+    {{ form_row(form.type, {'label': filter.label}) }}
+{% endif %}
+    {{ form_row(form.value, {attr: {placeholder: form.value.vars.label}, 'label': form.type is defined ? form.value.vars.label : filter.label}) }}


### PR DESCRIPTION
```php
#[AsFilter(
    formType: SourceFilterType::class,
    // This template configuration is the new feature implemented on that PR
    template: '@SyliusBootstrapAdminUi/shared/grid/filter/select.html.twig',
)]
final class SourceFilter implements FilterInterface
{
   // ...
}
```

```php
// config/packages/sylius_grid.php
return static function (ContainerConfigurator $containerConfigurator): void {
    $containerConfigurator->extension('sylius_grid', [
        'templates' => [
            'filter' => [
                // It allows to remove that configuration
                // SourceFilter::class => '@SyliusBootstrapAdminUi/shared/grid/filter/select.html.twig',
            ],
        ],
    ]);
};
```
