### PR TITLE
Add custom build method and grid provider

### DIFF
--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -81,6 +81,7 @@ final class Configuration implements ConfigurationInterface
                     ->arrayPrototype()
                         ->children()
                             ->scalarNode('extends')->cannotBeEmpty()->end()
+                            ->scalarNode('provider')->cannotBeEmpty()->end()
                             ->arrayNode('driver')
                                 ->addDefaultsIfNotSet()
                                 ->children()

--- a/src/Bundle/Doctrine/ORM/Driver.php
+++ b/src/Bundle/Doctrine/ORM/Driver.php
@@ -17,8 +17,8 @@ use Doctrine\ORM\EntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use Sylius\Component\Grid\Data\DataSourceInterface;
 use Sylius\Component\Grid\Data\DriverInterface;
+use Sylius\Component\Grid\Exception\RuntimeException;
 use Sylius\Component\Grid\Parameters;
-use Sylius\Resource\Exception\RuntimeException;
 
 final class Driver implements DriverInterface
 {
@@ -40,7 +40,7 @@ final class Driver implements DriverInterface
         $manager = $this->managerRegistry->getManagerForClass($configuration['class']);
 
         if (null === $manager) {
-            throw new RuntimeException('Manager for class "' . $configuration['class'] . '" not found.');
+            throw new RuntimeException(sprintf('Doctrine ORM manager for class "%s" not found.', $configuration['class']));
         }
 
         /** @var EntityRepository $repository */

--- a/src/Bundle/Doctrine/ORM/Driver.php
+++ b/src/Bundle/Doctrine/ORM/Driver.php
@@ -15,10 +15,10 @@ namespace Sylius\Bundle\GridBundle\Doctrine\ORM;
 
 use Doctrine\ORM\EntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
-use Doctrine\Persistence\ObjectManager;
 use Sylius\Component\Grid\Data\DataSourceInterface;
 use Sylius\Component\Grid\Data\DriverInterface;
 use Sylius\Component\Grid\Parameters;
+use Sylius\Resource\Exception\RuntimeException;
 
 final class Driver implements DriverInterface
 {
@@ -34,11 +34,14 @@ final class Driver implements DriverInterface
     public function getDataSource(array $configuration, Parameters $parameters): DataSourceInterface
     {
         if (!array_key_exists('class', $configuration)) {
-            throw new \InvalidArgumentException('"class" must be configured.');
+            throw new \InvalidArgumentException('Missing configuration: when using the ORM driver for a grid, you must define the "class" option.');
         }
 
-        /** @var ObjectManager $manager */
         $manager = $this->managerRegistry->getManagerForClass($configuration['class']);
+
+        if (null === $manager) {
+            throw new RuntimeException('Manager for class "' . $configuration['class'] . '" not found.');
+        }
 
         /** @var EntityRepository $repository */
         $repository = $manager->getRepository($configuration['class']);

--- a/src/Bundle/Grid/AbstractGrid.php
+++ b/src/Bundle/Grid/AbstractGrid.php
@@ -44,7 +44,7 @@ abstract class AbstractGrid implements GridInterface
         $buildMethod ??= 'buildGrid';
 
         if (!method_exists($this, $buildMethod)) {
-            throw new LogicException(sprintf('The build method "%s" you configured does not exist.', $buildMethod));
+            throw new LogicException(sprintf('The configured build method "%s" does not exist.', $buildMethod));
         }
 
         $this->$buildMethod($gridBuilder);

--- a/src/Bundle/Grid/AbstractGrid.php
+++ b/src/Bundle/Grid/AbstractGrid.php
@@ -16,6 +16,7 @@ namespace Sylius\Bundle\GridBundle\Grid;
 use Sylius\Bundle\GridBundle\Builder\GridBuilder;
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Component\Grid\Attribute\AsGrid;
+use Sylius\Component\Grid\Exception\LogicException;
 
 abstract class AbstractGrid implements GridInterface
 {
@@ -28,9 +29,31 @@ abstract class AbstractGrid implements GridInterface
     {
         $gridBuilder = $this->createGridBuilder();
 
-        $this->buildGrid($gridBuilder);
+        $provider = self::getAsGridAttribute()?->provider ?? null;
+
+        if (null !== $provider) {
+            $gridBuilder->setProvider($provider);
+        }
+
+        $buildMethod = self::getAsGridAttribute()?->buildMethod;
+
+        if (null === $buildMethod && method_exists($this, '__invoke')) {
+            $buildMethod = '__invoke';
+        }
+
+        $buildMethod ??= 'buildGrid';
+
+        if (!method_exists($this, $buildMethod)) {
+            throw new LogicException(sprintf('The build method "%s" you configured does not exist.', $buildMethod));
+        }
+
+        $this->$buildMethod($gridBuilder);
 
         return $gridBuilder->toArray();
+    }
+
+    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    {
     }
 
     private function createGridBuilder(): GridBuilderInterface

--- a/src/Bundle/Tests/DependencyInjection/GridBuilderConfigurationTest.php
+++ b/src/Bundle/Tests/DependencyInjection/GridBuilderConfigurationTest.php
@@ -39,9 +39,13 @@ use Sylius\Bundle\GridBundle\Builder\Filter\StringFilter;
 use Sylius\Bundle\GridBundle\Builder\GridBuilder;
 use Sylius\Bundle\GridBundle\DependencyInjection\SyliusGridExtension;
 use Sylius\Bundle\GridBundle\Doctrine\ORM\Driver;
-use Sylius\Component\Grid\Tests\Dummy\AttributeGrid;
+use Sylius\Component\Grid\Exception\LogicException;
+use Sylius\Component\Grid\Tests\Dummy\AttributeGridWithCustomBuildMethod;
+use Sylius\Component\Grid\Tests\Dummy\AttributeGridWithCustomBuildMethodThatDoesNotExist;
+use Sylius\Component\Grid\Tests\Dummy\AttributeGridWithProvider;
 use Sylius\Component\Grid\Tests\Dummy\AttributeWithResourceClassGrid;
 use Sylius\Component\Grid\Tests\Dummy\ClassAsParameterGrid;
+use Sylius\Component\Grid\Tests\Dummy\DummyGridProvider;
 use Sylius\Component\Grid\Tests\Dummy\Foo;
 use Sylius\Component\Grid\Tests\Dummy\FooFightersGrid;
 use Sylius\Component\Grid\Tests\Dummy\FooGrid;
@@ -54,7 +58,7 @@ final class GridBuilderConfigurationTest extends AbstractExtensionTestCase
      */
     public function it_builds_grid_with_only_a_name(): void
     {
-        $gridBuilder = GridBuilder::create('app_admin_book');
+        $gridBuilder = GridBuilder::create('app_admin_book', 'DummyResource');
 
         $this->load([
             'grids' => [
@@ -66,7 +70,9 @@ final class GridBuilderConfigurationTest extends AbstractExtensionTestCase
             'app_admin_book' => [
                 'driver' => [
                     'name' => Driver::NAME,
-                    'options' => [],
+                    'options' => [
+                        'class' => 'DummyResource',
+                    ],
                 ],
                 'removals' => [],
                 'sorting' => [],
@@ -790,6 +796,7 @@ final class GridBuilderConfigurationTest extends AbstractExtensionTestCase
 
         $this->assertContainerBuilderHasParameter('sylius.grids_definitions', [
             'app_no_resource' => [
+                'provider' => DummyGridProvider::class,
                 'driver' => [
                     'name' => Driver::NAME,
                     'options' => [],
@@ -904,33 +911,6 @@ final class GridBuilderConfigurationTest extends AbstractExtensionTestCase
     }
 
     /** @test */
-    public function it_builds_grid_with_a_grid_attribute(): void
-    {
-        $grid = new AttributeGrid();
-
-        $this->load([
-            'grids' => [
-                AttributeGrid::class => $grid->toArray(),
-            ],
-        ]);
-
-        $this->assertContainerBuilderHasParameter('sylius.grids_definitions', [
-            AttributeGrid::class => [
-                'driver' => [
-                    'name' => Driver::NAME,
-                    'options' => [],
-                ],
-                'removals' => [],
-                'sorting' => [],
-                'limits' => [10, 25, 50],
-                'fields' => [],
-                'filters' => [],
-                'actions' => [],
-            ],
-        ]);
-    }
-
-    /** @test */
     public function it_builds_grid_with_a_grid_attribute_with_defined_resource_class(): void
     {
         $grid = new AttributeWithResourceClassGrid();
@@ -943,6 +923,87 @@ final class GridBuilderConfigurationTest extends AbstractExtensionTestCase
 
         $this->assertContainerBuilderHasParameter('sylius.grids_definitions', [
             AttributeWithResourceClassGrid::class => [
+                'driver' => [
+                    'name' => Driver::NAME,
+                    'options' => [
+                        'class' => Foo::class,
+                    ],
+                ],
+                'removals' => [],
+                'sorting' => [],
+                'limits' => [10, 25, 50],
+                'fields' => [],
+                'filters' => [],
+                'actions' => [],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_builds_grid_with_a_grid_attribute_with_custom_build_method(): void
+    {
+        $grid = new AttributeGridWithCustomBuildMethod();
+
+        $this->load([
+            'grids' => [
+                AttributeGridWithCustomBuildMethod::class => $grid->toArray(),
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasParameter('sylius.grids_definitions', [
+            AttributeGridWithCustomBuildMethod::class => [
+                'driver' => [
+                    'name' => Driver::NAME,
+                    'options' => [
+                        'class' => Foo::class,
+                    ],
+                ],
+                'removals' => [],
+                'sorting' => [],
+                'limits' => [10, 25, 50],
+                'fields' => [
+                    'foo' => [
+                        'type' => 'string',
+                        'enabled' => true,
+                        'position' => 100,
+                        'options' => [],
+                    ],
+                ],
+                'filters' => [],
+                'actions' => [],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_throw_an_exception_when_the_custom_build_method_does_not_exist(): void
+    {
+        $grid = new AttributeGridWithCustomBuildMethodThatDoesNotExist();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The build method "nonExistingMethod" you configured does not exist.');
+
+        $this->load([
+            'grids' => [
+                AttributeGridWithCustomBuildMethodThatDoesNotExist::class => $grid->toArray(),
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_builds_grid_with_a_grid_attribute_with_defined_provider(): void
+    {
+        $grid = new AttributeGridWithProvider();
+
+        $this->load([
+            'grids' => [
+                AttributeGridWithProvider::class => $grid->toArray(),
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasParameter('sylius.grids_definitions', [
+            AttributeGridWithProvider::class => [
+                'provider' => DummyGridProvider::class,
                 'driver' => [
                     'name' => Driver::NAME,
                     'options' => [

--- a/src/Bundle/Tests/DependencyInjection/GridBuilderConfigurationTest.php
+++ b/src/Bundle/Tests/DependencyInjection/GridBuilderConfigurationTest.php
@@ -981,7 +981,7 @@ final class GridBuilderConfigurationTest extends AbstractExtensionTestCase
         $grid = new AttributeGridWithCustomBuildMethodThatDoesNotExist();
 
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('The build method "nonExistingMethod" you configured does not exist.');
+        $this->expectExceptionMessage('The configured build method "nonExistingMethod" does not exist.');
 
         $this->load([
             'grids' => [

--- a/src/Bundle/spec/Doctrine/ORM/DriverSpec.php
+++ b/src/Bundle/spec/Doctrine/ORM/DriverSpec.php
@@ -37,7 +37,7 @@ final class DriverSpec extends ObjectBehavior
     function it_throws_exception_if_class_is_undefined(): void
     {
         $this
-            ->shouldThrow(\InvalidArgumentException::class)
+            ->shouldThrow(new \InvalidArgumentException('Missing configuration: when using the ORM driver for a grid, you must define the "class" option.'))
             ->during('getDataSource', [[], new Parameters()])
         ;
     }

--- a/src/Component/Attribute/AsGrid.php
+++ b/src/Component/Attribute/AsGrid.php
@@ -19,6 +19,8 @@ final class AsGrid
     public function __construct(
         public readonly ?string $resourceClass = null,
         public readonly ?string $name = null,
+        public readonly ?string $buildMethod = null,
+        public readonly ?string $provider = null,
     ) {
     }
 }

--- a/src/Component/Exception/LogicException.php
+++ b/src/Component/Exception/LogicException.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Exception;
+
+class LogicException extends \LogicException implements ExceptionInterface
+{
+}

--- a/src/Component/Exception/RuntimeException.php
+++ b/src/Component/Exception/RuntimeException.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Exception;
+
+class RuntimeException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/src/Component/Tests/Dummy/AttributeGridWithCustomBuildMethod.php
+++ b/src/Component/Tests/Dummy/AttributeGridWithCustomBuildMethod.php
@@ -13,18 +13,16 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Grid\Tests\Dummy;
 
+use Sylius\Bundle\GridBundle\Builder\Field\StringField;
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\AbstractGrid;
+use Sylius\Component\Grid\Attribute\AsGrid;
 
-final class NoResourceGrid extends AbstractGrid
+#[AsGrid(resourceClass: Foo::class, buildMethod: 'customBuild')]
+final class AttributeGridWithCustomBuildMethod extends AbstractGrid
 {
-    public static function getName(): string
+    public function customBuild(GridBuilderInterface $gridBuilder): void
     {
-        return 'app_no_resource';
-    }
-
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
-    {
-        $gridBuilder->setProvider(DummyGridProvider::class);
+        $gridBuilder->addField(StringField::create('foo'));
     }
 }

--- a/src/Component/Tests/Dummy/AttributeGridWithCustomBuildMethodThatDoesNotExist.php
+++ b/src/Component/Tests/Dummy/AttributeGridWithCustomBuildMethodThatDoesNotExist.php
@@ -13,14 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Grid\Tests\Dummy;
 
-use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\AbstractGrid;
 use Sylius\Component\Grid\Attribute\AsGrid;
 
-#[AsGrid]
-final class AttributeGrid extends AbstractGrid
+#[AsGrid(resourceClass: Foo::class, buildMethod: 'nonExistingMethod')]
+final class AttributeGridWithCustomBuildMethodThatDoesNotExist extends AbstractGrid
 {
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
-    {
-    }
 }

--- a/src/Component/Tests/Dummy/AttributeGridWithProvider.php
+++ b/src/Component/Tests/Dummy/AttributeGridWithProvider.php
@@ -15,16 +15,12 @@ namespace Sylius\Component\Grid\Tests\Dummy;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\AbstractGrid;
+use Sylius\Component\Grid\Attribute\AsGrid;
 
-final class NoResourceGrid extends AbstractGrid
+#[AsGrid(resourceClass: Foo::class, provider: DummyGridProvider::class)]
+final class AttributeGridWithProvider extends AbstractGrid
 {
-    public static function getName(): string
-    {
-        return 'app_no_resource';
-    }
-
     public function buildGrid(GridBuilderInterface $gridBuilder): void
     {
-        $gridBuilder->setProvider(DummyGridProvider::class);
     }
 }

--- a/src/Component/Tests/Dummy/DummyGridProvider.php
+++ b/src/Component/Tests/Dummy/DummyGridProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Tests\Dummy;
+
+use Sylius\Component\Grid\Data\DataProviderInterface;
+use Sylius\Component\Grid\Definition\Grid;
+use Sylius\Component\Grid\Parameters;
+
+final class DummyGridProvider implements DataProviderInterface
+{
+    public function getData(Grid $grid, Parameters $parameters): array
+    {
+        return [];
+    }
+}

--- a/src/Component/Tests/Dummy/EmptyAttributeGrid.php
+++ b/src/Component/Tests/Dummy/EmptyAttributeGrid.php
@@ -15,16 +15,12 @@ namespace Sylius\Component\Grid\Tests\Dummy;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\AbstractGrid;
+use Sylius\Component\Grid\Attribute\AsGrid;
 
-final class NoResourceGrid extends AbstractGrid
+#[AsGrid]
+final class EmptyAttributeGrid extends AbstractGrid
 {
-    public static function getName(): string
-    {
-        return 'app_no_resource';
-    }
-
     public function buildGrid(GridBuilderInterface $gridBuilder): void
     {
-        $gridBuilder->setProvider(DummyGridProvider::class);
     }
 }


### PR DESCRIPTION
Based on #349 

```php
<?php

declare(strict_types=1);

namespace App\Hermes\UI\Admin\Grid;

use App\Hermes\Infrastructure\Sylius\Grid\Provider\PublisherGridProvider;
use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
use Sylius\Bundle\GridBundle\Grid\AbstractGrid;
use Sylius\Component\Grid\Attribute\AsGrid;

#[AsGrid(provider: PublisherGridProvider::class)]
final class PublisherGrid extends AbstractGrid
{
    public function __invoke(GridBuilderInterface $gridBuilder): void
    {
        $gridBuilder
            ->setLimits([10, 25, 50])
            // ...
        ;
    }
}
```

```php
<?php

declare(strict_types=1);

namespace App\Hermes\UI\Admin\Grid;

use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
use Sylius\Bundle\GridBundle\Grid\AbstractGrid;
use Sylius\Component\Grid\Attribute\AsGrid;

#[AsGrid(buildMethod: 'customBuild']
final class PublisherGrid extends AbstractGrid
{
    public function customBuild(GridBuilderInterface $gridBuilder): void
    {
        $gridBuilder
            ->setLimits([10, 25, 50])
            // ...
        ;
    }
}
```