### PR TITLE
fix: [make:grid Command] - make Doctrine ORM requirement optional

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,6 +120,12 @@ jobs:
                     composer test-with-postgres
 
             -
+                name: Run lint container without Doctrine
+                run: |
+                    composer remove --dev doctrine/*
+                    (cd tests/Application && bin/console lint:container)    
+
+            -
                 name: Run lint container without maker bundle
                 run: |
                     APP_ENV=test_without_maker composer remove --dev symfony/maker-bundle

--- a/src/Bundle/Maker/MakeGrid.php
+++ b/src/Bundle/Maker/MakeGrid.php
@@ -28,11 +28,8 @@ use Symfony\Component\Console\Input\InputOption;
 
 final class MakeGrid extends AbstractMaker
 {
-    private ManagerRegistry $managerRegistry;
-
-    public function __construct(ManagerRegistry $managerRegistry)
+    public function __construct(private readonly ?ManagerRegistry $managerRegistry = null)
     {
-        $this->managerRegistry = $managerRegistry;
     }
 
     public static function getCommandName(): string
@@ -92,22 +89,12 @@ final class MakeGrid extends AbstractMaker
         $entity = new \ReflectionClass($class);
         $grid = $generator->createClassNameDetails($entity->getShortName(), $namespace, 'Grid');
 
-        $repository = new \ReflectionClass($this->managerRegistry->getRepository($entity->getName()));
-
-        if (0 !== \mb_strpos($repository->getName(), $generator->getRootNamespace())) {
-            // not using a custom repository
-            $repository = null;
-        }
-
-        $this->defaultFieldsFor($entity->getName());
-
         $generator->generateClass(
             $grid->getFullName(),
             __DIR__ . '/../Resources/config/skeleton/Grid.tpl.php',
             [
                 'entity' => $entity,
                 'defaultFields' => $this->defaultFieldsFor($entity->getName()),
-                'repository' => $repository,
             ],
         );
 
@@ -125,7 +112,7 @@ final class MakeGrid extends AbstractMaker
     {
         $choices = [];
 
-        foreach ($this->managerRegistry->getManagers() as $manager) {
+        foreach ($this->managerRegistry?->getManagers() ?? [] as $manager) {
             foreach ($manager->getMetadataFactory()->getAllMetadata() as $metadata) {
                 $choices[] = $metadata->getName();
             }
@@ -143,7 +130,7 @@ final class MakeGrid extends AbstractMaker
     /** @param class-string $class */
     private function defaultFieldsFor(string $class): iterable
     {
-        $entityManager = $this->managerRegistry->getManagerForClass($class);
+        $entityManager = $this->managerRegistry?->getManagerForClass($class);
 
         if (!$entityManager instanceof EntityManagerInterface) {
             return [];

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -124,7 +124,7 @@
         </service>
 
         <service id="sylius.grid.maker" class="Sylius\Bundle\GridBundle\Maker\MakeGrid">
-            <argument type="service" id="doctrine" />
+            <argument type="service" id="doctrine" on-invalid="null" />
             <tag name="maker.command" />
         </service>
         <service id="Sylius\Bundle\GridBundle\Maker\MakeGrid" alias="sylius.grid.maker" />

--- a/src/Bundle/Tests/Functional/Maker/MakeGridTest.php
+++ b/src/Bundle/Tests/Functional/Maker/MakeGridTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\GridBundle\Tests\Functional\Maker;
 
+use App\BoardGameBlog\Infrastructure\Sylius\Resource\BoardGameResource;
 use App\Entity\AdminUser;
 use App\Entity\Book;
 use App\Entity\Price;
@@ -30,6 +31,8 @@ final class MakeGridTest extends MakerTestCase
 
     private const INVALID_GRID_PATH = 'Grid/InvalidGrid.php';
 
+    private const BOARD_GAME_GRID_PATH = 'Grid/BoardGameResourceGrid.php';
+
     /** @test */
     public function it_can_create_grids(): void
     {
@@ -41,6 +44,19 @@ final class MakeGridTest extends MakerTestCase
 
         $this->assertFileExists(self::tempFile(self::PRICE_GRID_PATH));
         $this->assertSame(self::getPriceGridExpectedContent(), \file_get_contents(self::tempFile(self::PRICE_GRID_PATH)));
+    }
+
+    /** @test */
+    public function it_can_create_grids_without_doctrine(): void
+    {
+        $tester = new CommandTester((new Application(self::bootKernel()))->find('make:grid'));
+
+        $this->assertFileDoesNotExist(self::tempFile(self::BOARD_GAME_GRID_PATH));
+
+        $tester->execute(['entity' => BoardGameResource::class, '--namespace' => 'Tests\Tmp\Grid']);
+
+        $this->assertFileExists(self::tempFile(self::BOARD_GAME_GRID_PATH));
+        $this->assertSame(self::getBoardGameGridExpectedContent(), \file_get_contents(self::tempFile(self::BOARD_GAME_GRID_PATH)));
     }
 
     /** @test */
@@ -80,7 +96,7 @@ final class MakeGridTest extends MakerTestCase
         $tester->execute(['--namespace' => 'Tests\Tmp\Grid']);
 
         $this->assertFileExists(self::tempFile(self::PRICE_GRID_PATH));
-        $this->assertSame(self::getPriceGridExpectedContent(), \file_get_contents(self::tempFile('Grid/PriceGrid.php')));
+        $this->assertSame(self::getPriceGridExpectedContent(), \file_get_contents(self::tempFile(self::PRICE_GRID_PATH)));
     }
 
     /** @test */
@@ -336,6 +352,71 @@ final class AdminUserGrid extends AbstractGrid implements ResourceAwareGridInter
     public function getResourceClass(): string
     {
         return AdminUser::class;
+    }
+}
+
+EOF
+        ;
+    }
+
+    private static function getBoardGameGridExpectedContent(): string
+    {
+        return <<<EOF
+<?php
+
+namespace App\Tests\Tmp\Grid;
+
+use App\BoardGameBlog\Infrastructure\Sylius\Resource\BoardGameResource;
+use Sylius\Bundle\GridBundle\Builder\Action\CreateAction;
+use Sylius\Bundle\GridBundle\Builder\Action\DeleteAction;
+use Sylius\Bundle\GridBundle\Builder\Action\ShowAction;
+use Sylius\Bundle\GridBundle\Builder\Action\UpdateAction;
+use Sylius\Bundle\GridBundle\Builder\ActionGroup\BulkActionGroup;
+use Sylius\Bundle\GridBundle\Builder\ActionGroup\ItemActionGroup;
+use Sylius\Bundle\GridBundle\Builder\ActionGroup\MainActionGroup;
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
+use Sylius\Bundle\GridBundle\Grid\AbstractGrid;
+use Sylius\Bundle\GridBundle\Grid\ResourceAwareGridInterface;
+
+final class BoardGameResourceGrid extends AbstractGrid implements ResourceAwareGridInterface
+{
+    public function __construct()
+    {
+        // TODO inject services if required
+    }
+
+    public static function getName(): string
+    {
+        return 'app_board_game_resource';
+    }
+
+    public function buildGrid(GridBuilderInterface \$gridBuilder): void
+    {
+        \$gridBuilder
+            // see https://github.com/Sylius/SyliusGridBundle/blob/master/docs/field_types.md
+            ->addActionGroup(
+                MainActionGroup::create(
+                    CreateAction::create(),
+                )
+            )
+            ->addActionGroup(
+                ItemActionGroup::create(
+                    // ShowAction::create(),
+                    UpdateAction::create(),
+                    DeleteAction::create()
+                )
+            )
+            ->addActionGroup(
+                BulkActionGroup::create(
+                    DeleteAction::create()
+                )
+            )
+        ;
+    }
+
+    public function getResourceClass(): string
+    {
+        return BoardGameResource::class;
     }
 }
 


### PR DESCRIPTION
This PR aims to prevent an exception being thrown when installing the SyliusGridBundle on an existing project without Doctrine ORM.

![image](https://github.com/user-attachments/assets/b14524d9-0ccf-4304-8378-592bd57d78d9)
