### PR TITLE
Improve make grid command to be run with Doctrine Entities or any other Object resource class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /composer.lock
 
 /.phpunit.result.cache
-src/Bundle/test/tmp
+tests/Application/tmp
 
 src/Bundle/test/vendor/
 src/Bundle/test/composer.lock

--- a/src/Bundle/Maker/MakeGrid.php
+++ b/src/Bundle/Maker/MakeGrid.php
@@ -25,6 +25,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Webmozart\Assert\Assert;
 
 final class MakeGrid extends AbstractMaker
 {
@@ -39,7 +40,7 @@ final class MakeGrid extends AbstractMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Creates a Grid for a Doctrine entity class';
+        return 'Creates a Sylius Grid configuration for a given resource class or Doctrine entity.';
     }
 
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void
@@ -133,7 +134,25 @@ final class MakeGrid extends AbstractMaker
         $entityManager = $this->managerRegistry?->getManagerForClass($class);
 
         if (!$entityManager instanceof EntityManagerInterface) {
-            return [];
+            $metadata = new \ReflectionClass($class);
+            $fieldMappings = $metadata->getProperties();
+
+            foreach ($fieldMappings as $property) {
+                // ignore identifier
+                if ('id' === $property->getName()) {
+                    continue;
+                }
+
+                Assert::isInstanceOf($property->getType(), \ReflectionNamedType::class);
+
+                $propertyType = $property->getType()->getName();
+
+                $type = $propertyType ? \mb_strtoupper($propertyType) : null;
+
+                yield $property->getName() => $type;
+            }
+
+            return;
         }
 
         $metadata = $entityManager->getClassMetadata($class);
@@ -149,7 +168,5 @@ final class MakeGrid extends AbstractMaker
 
             yield $property['fieldName'] => $type;
         }
-
-        return [];
     }
 }

--- a/src/Bundle/Resources/config/skeleton/Grid.tpl.php
+++ b/src/Bundle/Resources/config/skeleton/Grid.tpl.php
@@ -55,7 +55,7 @@ foreach ($defaultFields as $fieldname => $type) {
         echo "            )\n";
     }
 
-    if ('BOOLEAN' === $type) {
+    if (in_array($type, ['BOOLEAN', 'BOOL'], true)) {
         echo "            //->addField(\n";
         echo "            //    TwigField::create('" . $fieldname . "', 'path/to/field/template.html.twig')\n";
         echo "            //        ->setLabel('" . ucfirst($fieldname) . "')\n";

--- a/src/Bundle/Tests/Functional/Maker/MakeGridTest.php
+++ b/src/Bundle/Tests/Functional/Maker/MakeGridTest.php
@@ -34,7 +34,7 @@ final class MakeGridTest extends MakerTestCase
     private const BOARD_GAME_GRID_PATH = 'Grid/BoardGameResourceGrid.php';
 
     /** @test */
-    public function it_can_create_grids(): void
+    public function it_can_create_grids_with_a_doctrine_entity(): void
     {
         $tester = new CommandTester((new Application(self::bootKernel()))->find('make:grid'));
 

--- a/src/Bundle/Tests/Functional/Maker/MakeGridTest.php
+++ b/src/Bundle/Tests/Functional/Maker/MakeGridTest.php
@@ -374,6 +374,7 @@ use Sylius\Bundle\GridBundle\Builder\Action\UpdateAction;
 use Sylius\Bundle\GridBundle\Builder\ActionGroup\BulkActionGroup;
 use Sylius\Bundle\GridBundle\Builder\ActionGroup\ItemActionGroup;
 use Sylius\Bundle\GridBundle\Builder\ActionGroup\MainActionGroup;
+use Sylius\Bundle\GridBundle\Builder\Field\StringField;
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\AbstractGrid;
 use Sylius\Bundle\GridBundle\Grid\ResourceAwareGridInterface;
@@ -394,6 +395,16 @@ final class BoardGameResourceGrid extends AbstractGrid implements ResourceAwareG
     {
         \$gridBuilder
             // see https://github.com/Sylius/SyliusGridBundle/blob/master/docs/field_types.md
+            ->addField(
+                StringField::create('name')
+                    ->setLabel('Name')
+                    ->setSortable(true)
+            )
+            ->addField(
+                StringField::create('shortDescription')
+                    ->setLabel('ShortDescription')
+                    ->setSortable(true)
+            )
             ->addActionGroup(
                 MainActionGroup::create(
                     CreateAction::create(),

--- a/tests/Application/config/doctrine/Book.orm.yml
+++ b/tests/Application/config/doctrine/Book.orm.yml
@@ -16,7 +16,7 @@ App\Entity\Book:
             length: 255
         state:
             type: string
-            lenght: 20
+            length: 20
             nullable: false
         enabled:
             type: boolean


### PR DESCRIPTION
The current implementation of the `make:grid` command assumes a Doctrine entity as the only valid input.
This PR introduces enhanced flexibility to the command by allowing developers to generate grids based on resource classes beyond standard Doctrine entities.

With this change, you can use any PHP class—such as a Sylius Resource implementation—as the basis for your grid configuration. This makes the command more versatile and better suited to projects using custom resource patterns or non-standard data sources.
Example usage:

```shell
symfony console make:grid 'App\BoardGameBlog\Infrastructure\\Sylius\Resource\BoardGameResource'
```

This command will now correctly scaffold a grid using the specified class, even if it is not a traditional Doctrine entity.

Based on #373 
