### PR TITLE
Allow to define a template in action definition

### DIFF
--- a/src/Bundle/Builder/Action/Action.php
+++ b/src/Bundle/Builder/Action/Action.php
@@ -23,6 +23,8 @@ final class Action implements ActionInterface
 
     private ?bool $enabled = null;
 
+    private ?string $template = null;
+
     private ?string $icon = null;
 
     private array $options = [];
@@ -59,6 +61,18 @@ final class Action implements ActionInterface
         return $this;
     }
 
+    public function getTemplate(): ?string
+    {
+        return $this->template;
+    }
+
+    public function setTemplate(string $template): ActionInterface
+    {
+        $this->template = $template;
+
+        return $this;
+    }
+
     public function setIcon(string $icon): ActionInterface
     {
         $this->icon = $icon;
@@ -90,6 +104,10 @@ final class Action implements ActionInterface
 
         if (null !== $this->enabled) {
             $output['enabled'] = $this->enabled;
+        }
+
+        if (null !== $this->template) {
+            $output['template'] = $this->template;
         }
 
         if (null !== $this->icon) {

--- a/src/Bundle/Builder/Action/ActionInterface.php
+++ b/src/Bundle/Builder/Action/ActionInterface.php
@@ -13,6 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\GridBundle\Builder\Action;
 
+/**
+ * @method string getTemplate()
+ * @method self setTemplate(string $template)
+ */
 interface ActionInterface
 {
     public static function create(string $name, string $type): self;

--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -149,6 +149,7 @@ final class Configuration implements ConfigurationInterface
                                             ->scalarNode('type')->isRequired()->end()
                                             ->scalarNode('label')->end()
                                             ->scalarNode('enabled')->defaultTrue()->end()
+                                            ->scalarNode('template')->end()
                                             ->scalarNode('icon')->end()
                                             ->scalarNode('position')->defaultValue(100)->end()
                                             ->arrayNode('options')

--- a/src/Bundle/Renderer/TwigGridRenderer.php
+++ b/src/Bundle/Renderer/TwigGridRenderer.php
@@ -99,11 +99,13 @@ final class TwigGridRenderer implements GridRendererInterface
     public function renderAction(GridViewInterface $gridView, Action $action, $data = null)
     {
         $type = $action->getType();
-        if (!isset($this->actionTemplates[$type])) {
+        $template = $action->getTemplate() ?? $this->actionTemplates[$type] ?? null;
+
+        if (null === $template) {
             throw new \InvalidArgumentException(sprintf('Missing template for action type "%s".', $type));
         }
 
-        return $this->twig->render($this->actionTemplates[$type], [
+        return $this->twig->render($template, [
             'grid' => $gridView,
             'action' => $action,
             'data' => $data,

--- a/src/Bundle/spec/Builder/Action/ActionSpec.php
+++ b/src/Bundle/spec/Builder/Action/ActionSpec.php
@@ -55,6 +55,18 @@ final class ActionSpec extends ObjectBehavior
         $action->toArray()['enabled']->shouldReturn(false);
     }
 
+    function it_has_no_template_by_default(): void
+    {
+        $this->getTemplate()->shouldReturn(null);
+    }
+
+    function it_sets_template(): void
+    {
+        $this->setTemplate('/path/to/template');
+
+        $this->getTemplate()->shouldReturn('/path/to/template');
+    }
+
     function it_sets_icon(): void
     {
         $action = $this->setIcon('cogs');

--- a/src/Bundle/spec/Renderer/TwigGridRendererSpec.php
+++ b/src/Bundle/spec/Renderer/TwigGridRendererSpec.php
@@ -78,6 +78,7 @@ final class TwigGridRendererSpec extends ObjectBehavior
     function it_uses_twig_to_render_the_action(Environment $twig, GridViewInterface $gridView, Action $action): void
     {
         $action->getType()->willReturn('link');
+        $action->getTemplate()->willReturn(null)->shouldBeCalled();
         $action->getOptions()->willReturn([]);
 
         $twig
@@ -90,6 +91,40 @@ final class TwigGridRendererSpec extends ObjectBehavior
         ;
 
         $this->renderAction($gridView, $action)->shouldReturn('<a href="#">Action!</a>');
+    }
+
+    function it_uses_custom_action_template_if_specified(
+        GridViewInterface $gridView,
+        Action $action,
+        Environment $twig,
+    ): void {
+        $action->getType()->willReturn('foo')->shouldBeCalled();
+        $action->getTemplate()->willReturn('path/to/template')->shouldBeCalled();
+
+        $twig
+            ->render('path/to/template', [
+                'grid' => $gridView,
+                'action' => $action,
+                'data' => null,
+            ])
+            ->willReturn('<a href="#">Action!</a>')
+            ->shouldBeCalled()
+        ;
+
+        $this->renderAction($gridView, $action, null);
+    }
+
+    function it_throws_an_exception_if_template_is_not_configured_for_given_action_type(
+        GridViewInterface $gridView,
+        Action $action,
+    ): void {
+        $action->getType()->willReturn('foo')->shouldBeCalled();
+        $action->getTemplate()->willReturn(null)->shouldBeCalled();
+
+        $this
+            ->shouldThrow(new \InvalidArgumentException('Missing template for action type "foo".'))
+            ->during('renderAction', [$gridView, $action])
+        ;
     }
 
     function it_renders_a_field_with_data_via_appropriate_field_type(
@@ -158,17 +193,5 @@ final class TwigGridRendererSpec extends ObjectBehavior
         $fieldType->render($field, 'Value', ['foo' => 'bar'])->willReturn('<strong>Value</strong>');
 
         $this->renderField($gridView, $field, 'Value')->shouldReturn('<strong>Value</strong>');
-    }
-
-    function it_throws_an_exception_if_template_is_not_configured_for_given_action_type(
-        GridViewInterface $gridView,
-        Action $action,
-    ): void {
-        $action->getType()->willReturn('foo');
-
-        $this
-            ->shouldThrow(new \InvalidArgumentException('Missing template for action type "foo".'))
-            ->during('renderAction', [$gridView, $action])
-        ;
     }
 }

--- a/src/Component/Definition/Action.php
+++ b/src/Component/Definition/Action.php
@@ -23,6 +23,8 @@ class Action
 
     private bool $enabled = true;
 
+    private ?string $template = null;
+
     private ?string $icon = null;
 
     /** @var array */
@@ -73,6 +75,16 @@ class Action
     public function setEnabled(bool $enabled): void
     {
         $this->enabled = $enabled;
+    }
+
+    public function getTemplate(): ?string
+    {
+        return $this->template;
+    }
+
+    public function setTemplate(string $template): void
+    {
+        $this->template = $template;
     }
 
     public function getIcon(): ?string

--- a/src/Component/Definition/ArrayToDefinitionConverter.php
+++ b/src/Component/Definition/ArrayToDefinitionConverter.php
@@ -145,6 +145,9 @@ final class ArrayToDefinitionConverter implements ArrayToDefinitionConverterInte
         if (array_key_exists('label', $configuration)) {
             $action->setLabel($configuration['label']);
         }
+        if (array_key_exists('template', $configuration)) {
+            $action->setTemplate($configuration['template']);
+        }
         if (array_key_exists('icon', $configuration)) {
             $action->setIcon($configuration['icon']);
         }

--- a/src/Component/spec/Definition/ActionSpec.php
+++ b/src/Component/spec/Definition/ActionSpec.php
@@ -53,6 +53,17 @@ final class ActionSpec extends ObjectBehavior
         $this->isEnabled()->shouldReturn(true);
     }
 
+    function it_has_no_template_by_default(): void
+    {
+        $this->getTemplate()->shouldReturn(null);
+    }
+
+    function its_template_is_mutable(): void
+    {
+        $this->setTemplate('path/to/action/template');
+        $this->getTemplate()->shouldReturn('path/to/action/template');
+    }
+
     function it_has_no_icon_by_default(): void
     {
         $this->getIcon()->shouldReturn(null);

--- a/src/Component/spec/Definition/ArrayToDefinitionConverterSpec.php
+++ b/src/Component/spec/Definition/ArrayToDefinitionConverterSpec.php
@@ -84,6 +84,7 @@ final class ArrayToDefinitionConverterSpec extends ObjectBehavior
 
         $viewAction = Action::fromNameAndType('view', 'link');
         $viewAction->setLabel('Display Tax Category');
+        $viewAction->setTemplate('path/to/action/template');
         $viewAction->setOptions(['foo' => 'bar']);
         $defaultActionGroup = ActionGroup::named('default');
         $defaultActionGroup->addAction($viewAction);
@@ -159,6 +160,7 @@ final class ArrayToDefinitionConverterSpec extends ObjectBehavior
                         'options' => [
                             'foo' => 'bar',
                         ],
+                        'template' => 'path/to/action/template',
                     ],
                 ],
             ],

--- a/tests/Application/config/routes.yaml
+++ b/tests/Application/config/routes.yaml
@@ -7,10 +7,12 @@ app_books:
     type: sylius.resource
 
 app_book_show:
-    path: /books/{id}}
+    path: /books/{id}
     methods: [ GET ]
     defaults:
         _controller: app.controller.book::showAction
+        _sylius:
+            template: 'book/show.html.twig'
 
 app_author:
     resource: |

--- a/tests/Application/config/sylius/grids.yaml
+++ b/tests/Application/config/sylius/grids.yaml
@@ -55,6 +55,10 @@ sylius_grid:
                     options:
                         vars:
                             th_class: "text-end"
+            actions:
+                item:
+                    show:
+                        type: show
             limits: [10, 5, 15]
 
         app_author:

--- a/tests/Application/templates/book/show.html.twig
+++ b/tests/Application/templates/book/show.html.twig
@@ -1,0 +1,6 @@
+<h2>{{ book.title }}</h2>
+
+<ul>
+    <li><strong>Author:</strong> {{ book.author|default('-') }}</li>
+    <li><strong>Price:</strong> {{ book.price.amount|default('-') }}</li>
+</ul>


### PR DESCRIPTION
Replace #376 

```php
final class SubscriptionGrid extends AbstractGrid 
{
    public function buildGrid(GridBuilderInterface $gridBuilder): void
    {
        $gridBuilder
            ->addActionGroup(
                ItemActionGroup::create(
                    Action::create('show', 'custom_show')
                        ->setTemplate('grid/action/show.html.twig')
                    ,
                )
            )
        ;
    }
}           
``` 

⚠️ We cannot use this feature in the test application for now, cause the TwigGridRenderer from Resource bundle needs to use this template getter first.

In the package, there are two ways of defining the template.
1/ On Field => within options property
2/ On Filter => directly within template property

Indeed the grid could be used in non-Twig/non-HTML context. 
Definining the template in the options could be more detached to "HTML", but I think it's simpler for the DX to define this within a simple setTemplate. For now we use grids within HTML in 100% of the case, and even I already have some PoC to define console operations with grids, this is not bad to keep that getter/setter unused there.