### PR TITLE
Improve enum support with EnumField and EnumFilter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,6 +77,7 @@
         "symfony/dotenv": "^6.4 || ^7.0",
         "symfony/maker-bundle": "^1.36",
         "symfony/polyfill-mbstring": "<1.22.0 || >1.22.0",
+        "symfony/translation": "^6.4 || ^7.0",
         "symfony/twig-bundle": "^6.4 || ^7.0",
         "twig/twig": "^2.12 || ^3.0",
         "vimeo/psalm": "^5.23",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1465,6 +1465,12 @@ parameters:
 			path: src/Component/FieldTypes/DatetimeFieldType.php
 
 		-
+			message: '#^Method Sylius\\Component\\Grid\\FieldTypes\\EnumFieldType\:\:render\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Component/FieldTypes/EnumFieldType.php
+
+		-
 			message: '#^Method Sylius\\Component\\Grid\\FieldTypes\\FieldTypeInterface\:\:render\(\) has parameter \$options with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/src/Bundle/Builder/Field/EnumField.php
+++ b/src/Bundle/Builder/Field/EnumField.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\GridBundle\Builder\Field;
+
+final class EnumField
+{
+    public static function create(string $name): FieldInterface
+    {
+        return Field::create($name, 'enum');
+    }
+}

--- a/src/Bundle/Builder/Filter/EnumFilter.php
+++ b/src/Bundle/Builder/Filter/EnumFilter.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\GridBundle\Builder\Filter;
+
+final class EnumFilter
+{
+    public static function create(string $name, string $enumClass, ?bool $multiple = null, ?string $field = null): FilterInterface
+    {
+        $filter = Filter::create($name, 'enum');
+
+        $filter->setFormOptions(['class' => $enumClass]);
+
+        if (null !== $field) {
+            $filter->setOptions(['field' => $field]);
+        }
+
+        if (null !== $multiple) {
+            $filter->addFormOption('multiple', $multiple);
+        }
+
+        return $filter;
+    }
+}

--- a/src/Bundle/Form/Type/Filter/EnumFilterType.php
+++ b/src/Bundle/Form/Type/Filter/EnumFilterType.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\GridBundle\Form\Type\Filter;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EnumType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class EnumFilterType extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver
+            ->setDefault('placeholder', 'sylius.ui.all')
+        ;
+    }
+
+    public function getParent(): string
+    {
+        return EnumType::class;
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_grid_filter_enum';
+    }
+}

--- a/src/Bundle/Resources/config/services/field_types.xml
+++ b/src/Bundle/Resources/config/services/field_types.xml
@@ -34,5 +34,12 @@
             <tag name="sylius.grid_field" type="string" />
         </service>
         <service id="Sylius\Component\Grid\FieldTypes\StringFieldType" alias="sylius.grid_field.string" />
+
+        <service id="sylius.grid_field.enum" class="Sylius\Component\Grid\FieldTypes\EnumFieldType">
+            <argument type="service" id="sylius.grid.data_extractor" />
+            <argument type="service" id="translator" on-invalid="null" />
+            <tag name="sylius.grid_field" type="enum" />
+        </service>
+        <service id="Sylius\Component\Grid\FieldTypes\EnumFieldType" alias="sylius.grid_field.enum" />
     </services>
 </container>

--- a/src/Bundle/Resources/config/services/filters.xml
+++ b/src/Bundle/Resources/config/services/filters.xml
@@ -92,5 +92,14 @@
             <tag name="form.type" />
         </service>
         <service id="Sylius\Bundle\GridBundle\Form\Type\Filter\SelectFilterType" alias="sylius.form.type.grid_filter.select" />
+
+        <service id="sylius.grid_filter.enum" class="Sylius\Component\Grid\Filter\SelectFilter">
+            <tag name="sylius.grid_filter" type="enum" form-type="Sylius\Bundle\GridBundle\Form\Type\Filter\EnumFilterType" />
+        </service>
+
+        <service id="sylius.form.type.grid_filter.enum" class="Sylius\Bundle\GridBundle\Form\Type\Filter\EnumFilterType">
+            <tag name="form.type" />
+        </service>
+        <service id="Sylius\Bundle\GridBundle\Form\Type\Filter\EnumFilterType" alias="sylius.form.type.grid_filter.enum" />
     </services>
 </container>

--- a/src/Bundle/Tests/DataFixtures/ORM/fixtures.yml
+++ b/src/Bundle/Tests/DataFixtures/ORM/fixtures.yml
@@ -46,3 +46,14 @@ App\Entity\Price:
     price_2:
         amount: 1000
         currencyCode: "GBP"
+
+App\Entity\AdminUser:
+    user_1:
+        username: "<firstName()><lastName()>"
+        status: "active"
+    user_2:
+        username: "<firstName()><lastName()>"
+        status: "inactive"
+    user_3:
+        username: "<firstName()><lastName()>"
+        status: "banned"

--- a/src/Bundle/Tests/Functional/GridUiTest.php
+++ b/src/Bundle/Tests/Functional/GridUiTest.php
@@ -286,6 +286,19 @@ final class GridUiTest extends ApiTestCase
         $this->assertSame($totalItemsCountBeforeSorting, $totalItemsCountAfterSorting);
     }
 
+    /** @test */
+    public function it_shows_admin_user_status_enums(): void
+    {
+        $this->client->request('GET', '/admin-users/');
+
+        $statusses = $this->getAdminStatussesFromResponse();
+
+        $this->assertCount(3, $statusses);
+        $this->assertContains('enum.status.active', $statusses);
+        $this->assertContains('enum.status.inactive', $statusses);
+        $this->assertContains('enum.status.banned', $statusses);
+    }
+
     /** @return string[] */
     private function getBookTitlesFromResponse(): array
     {
@@ -341,6 +354,16 @@ final class GridUiTest extends ApiTestCase
     {
         return $this->getCrawler()
             ->filter('[data-test-name]')
+            ->each(
+                fn (Crawler $node): string => $node->text(),
+            );
+    }
+
+    /** @return string[] */
+    private function getAdminStatussesFromResponse(): array
+    {
+        return $this->getCrawler()
+            ->filter('[data-test-status]')
             ->each(
                 fn (Crawler $node): string => $node->text(),
             );

--- a/src/Bundle/Tests/Functional/Maker/MakeGridTest.php
+++ b/src/Bundle/Tests/Functional/Maker/MakeGridTest.php
@@ -316,6 +316,11 @@ final class AdminUserGrid extends AbstractGrid
                     ->setLabel('Username')
                     ->setSortable(true)
             )
+            ->addField(
+                StringField::create('status')
+                    ->setLabel('Status')
+                    ->setSortable(true)
+            )
             ->addActionGroup(
                 MainActionGroup::create(
                     CreateAction::create(),

--- a/src/Component/FieldTypes/EnumFieldType.php
+++ b/src/Component/FieldTypes/EnumFieldType.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\FieldTypes;
+
+use Sylius\Component\Grid\DataExtractor\DataExtractorInterface;
+use Sylius\Component\Grid\Definition\Field;
+use Sylius\Component\Grid\Exception\LogicException;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Webmozart\Assert\Assert;
+
+final class EnumFieldType implements FieldTypeInterface
+{
+    public function __construct(
+        private DataExtractorInterface $dataExtractor,
+        private ?TranslatorInterface $translator = null,
+    ) {
+    }
+
+    public function render(Field $field, $data, array $options): string
+    {
+        $enum = $this->dataExtractor->get($field, $data);
+
+        if (null === $enum) {
+            return '';
+        }
+
+        Assert::isInstanceOf($enum, \UnitEnum::class);
+
+        if ($enum instanceof TranslatableInterface) {
+            if (null === $this->translator) {
+                throw new LogicException('You have configured a translatable enum, but Symfony translator is not available. Try running "composer require symfony/translator".');
+            }
+
+            return $enum->trans($this->translator);
+        }
+
+        if ($enum instanceof \BackedEnum) {
+            return (string) $enum->value;
+        }
+
+        return $enum->name;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefined('vars');
+        $resolver->setAllowedTypes('vars', 'array');
+    }
+}

--- a/src/Component/Tests/Dummy/TestEnum.php
+++ b/src/Component/Tests/Dummy/TestEnum.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Tests\Dummy;
+
+enum TestEnum: string
+{
+    case A = 'a';
+}

--- a/src/Component/Tests/Dummy/TestNonBackedEnum.php
+++ b/src/Component/Tests/Dummy/TestNonBackedEnum.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Tests\Dummy;
+
+enum TestNonBackedEnum
+{
+    case A;
+}

--- a/src/Component/Tests/Dummy/TestTranslatableEnum.php
+++ b/src/Component/Tests/Dummy/TestTranslatableEnum.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Tests\Dummy;
+
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+enum TestTranslatableEnum: string implements TranslatableInterface
+{
+    case A = 'a';
+
+    public function trans(TranslatorInterface $translator, ?string $locale = null): string
+    {
+        return $this->value . '.translation';
+    }
+}

--- a/src/Component/Tests/Unit/FieldTypes/EnumFieldTypeTest.php
+++ b/src/Component/Tests/Unit/FieldTypes/EnumFieldTypeTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Tests\Unit\FieldTypes;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Grid\DataExtractor\DataExtractorInterface;
+use Sylius\Component\Grid\Definition\Field;
+use Sylius\Component\Grid\Exception\LogicException;
+use Sylius\Component\Grid\FieldTypes\EnumFieldType;
+use Sylius\Component\Grid\FieldTypes\FieldTypeInterface;
+use Sylius\Component\Grid\Tests\Dummy\TestEnum;
+use Sylius\Component\Grid\Tests\Dummy\TestNonBackedEnum;
+use Sylius\Component\Grid\Tests\Dummy\TestTranslatableEnum;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Webmozart\Assert\InvalidArgumentException;
+
+final class EnumFieldTypeTest extends TestCase
+{
+    private DataExtractorInterface|MockObject $dataExtractorMock;
+
+    private EnumFieldType $enumFieldType;
+
+    private Field $enumField;
+
+    protected function setUp(): void
+    {
+        $this->dataExtractorMock = $this->createMock(DataExtractorInterface::class);
+        $this->enumFieldType = new EnumFieldType($this->dataExtractorMock, $this->createMock(TranslatorInterface::class));
+        $this->enumField = Field::fromNameAndType('status', 'enum');
+    }
+
+    public function testAGridFieldType(): void
+    {
+        $this->assertInstanceOf(FieldTypeInterface::class, $this->enumFieldType);
+    }
+
+    public function testUsesDataExtractorToObtainDataAndRendersIt(): void
+    {
+        $this->dataExtractorMock->expects($this->once())->method('get')->with($this->enumField, ['foo' => 'bar'])->willReturn(TestEnum::A);
+
+        $this->assertSame('a', $this->enumFieldType->render($this->enumField, ['foo' => 'bar'], []));
+    }
+
+    public function testUsesDataExtractorToObtainDataParseWithGivenConfigurationAndTranslatorAndRendersIt(): void
+    {
+        $this->dataExtractorMock->expects($this->once())->method('get')->with($this->enumField, ['foo' => 'bar'])->willReturn(TestTranslatableEnum::A);
+
+        $this->assertSame('a.translation', $this->enumFieldType->render($this->enumField, ['foo' => 'bar'], []));
+    }
+
+    public function testUsesDataExtractorToObtainDataParseWithGivenConfigurationAndWithoutTranslationPackage(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('You have configured a translatable enum, but Symfony translator is not available. Try running "composer require symfony/translator".');
+
+        $this->dataExtractorMock->expects($this->once())->method('get')->with($this->enumField, ['foo' => 'bar'])->willReturn(TestTranslatableEnum::A);
+
+        $enumFieldType = new EnumFieldType($this->dataExtractorMock);
+        $this->assertSame('a.translation', $enumFieldType->render($this->enumField, ['foo' => 'bar'], []));
+    }
+
+    public function testUsesDataExtractorToObtainNonBackedEnumDataParseWithGivenConfigurationAndTranslatorAndRendersIt(): void
+    {
+        $this->dataExtractorMock->expects($this->once())->method('get')->with($this->enumField, ['foo' => 'bar'])->willReturn(TestNonBackedEnum::A);
+
+        $this->assertSame('A', $this->enumFieldType->render($this->enumField, ['foo' => 'bar'], []));
+    }
+
+    public function testUsesDataExtractorToObtainNullDataParseWithGivenConfigurationAndTranslatorAndRendersIt(): void
+    {
+        $this->dataExtractorMock->expects($this->once())->method('get')->with($this->enumField, ['foo' => 'bar'])->willReturn(null);
+
+        $this->assertSame('', $this->enumFieldType->render($this->enumField, ['foo' => 'bar'], []));
+    }
+
+    public function testUsesDataExtractorWithInvalidData(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected an instance of UnitEnum. Got: string');
+
+        $this->dataExtractorMock->expects($this->once())->method('get')->with($this->enumField, ['foo' => 'bar'])->willReturn('testvalue');
+
+        $this->assertSame('', $this->enumFieldType->render($this->enumField, ['foo' => 'bar'], []));
+    }
+}

--- a/tests/Application/config/packages/sylius_grid.yaml
+++ b/tests/Application/config/packages/sylius_grid.yaml
@@ -13,3 +13,4 @@ sylius_grid:
             select: 'grid/filter/select.html.twig'
             string: 'grid/filter/string.html.twig'
             nationality: 'grid/filter/entity.html.twig'
+            enum: 'grid/filter/enum.html.twig'

--- a/tests/Application/config/routes.yaml
+++ b/tests/Application/config/routes.yaml
@@ -77,3 +77,11 @@ app_author_with_books_with_use_output_walkers_enabled:
         _sylius:
             grid: app_author_with_books_with_use_output_walkers_enabled
             template: crud/index.html.twig
+
+app_admin_users:
+    resource: |
+        alias: app.admin_user
+        grid: app_admin_user
+        only: ['index']
+        templates: crud
+    type: sylius.resource

--- a/tests/Application/config/sylius/grids.yaml
+++ b/tests/Application/config/sylius/grids.yaml
@@ -208,3 +208,25 @@ sylius_grid:
                     type: string
                     path: books[0].title
                     sortable: book.title
+
+        app_admin_user:
+            driver:
+                name: doctrine/orm
+                options:
+                    class: App\Entity\AdminUser
+            filters:
+                username:
+                    type: string
+                status:
+                    type: enum
+                    form_options:
+                        class: App\Enum\AdminUserStatusEnum
+                        multiple: true
+            fields:
+                username:
+                    type: string
+                    label: Username
+                status:
+                    type: enum
+                    label: Status
+            limits: [10, 5, 15, 100]

--- a/tests/Application/config/sylius/grids/admin_user.php
+++ b/tests/Application/config/sylius/grids/admin_user.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+use App\Entity\AdminUser;
+use App\Enum\AdminUserStatusEnum;
+use Sylius\Bundle\GridBundle\Builder\Field\EnumField;
+use Sylius\Bundle\GridBundle\Builder\Field\StringField;
+use Sylius\Bundle\GridBundle\Builder\Filter\EnumFilter;
+use Sylius\Bundle\GridBundle\Builder\Filter\StringFilter;
+use Sylius\Bundle\GridBundle\Builder\GridBuilder;
+use Sylius\Bundle\GridBundle\Config\GridConfig;
+
+return static function (GridConfig $grid) {
+    $grid->addGrid(
+        GridBuilder::create('app_admin_user', AdminUser::class)
+        ->addFilter(StringFilter::create('username'))
+        ->addFilter(EnumFilter::create('status', AdminUserStatusEnum::class, true))
+        ->addField(
+            StringField::create('username')
+                ->setLabel('Username')
+                ->setSortable(true),
+        )
+        ->addField(
+            EnumField::create('status')
+                ->setLabel('Status'),
+        )
+        ->setLimits([10, 5, 15, 100]),
+    );
+};

--- a/tests/Application/config/sylius/resources.yaml
+++ b/tests/Application/config/sylius/resources.yaml
@@ -21,3 +21,7 @@ sylius_resource:
         app.nationality:
             classes:
                 model: App\Entity\Nationality
+
+        app.admin_user:
+            classes:
+                model: App\Entity\AdminUser

--- a/tests/Application/src/Entity/AdminUser.php
+++ b/tests/Application/src/Entity/AdminUser.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use App\Enum\AdminUserStatusEnum;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Resource\Model\ResourceInterface;
 
@@ -28,6 +29,9 @@ class AdminUser implements ResourceInterface
     #[ORM\Column(type: 'string', length: 255)]
     private ?string $username = null;
 
+    #[ORM\Column(enumType: AdminUserStatusEnum::class)]
+    private AdminUserStatusEnum $status = AdminUserStatusEnum::Active;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -36,5 +40,20 @@ class AdminUser implements ResourceInterface
     public function getUsername(): ?string
     {
         return $this->username;
+    }
+
+    public function setUsername(?string $username): void
+    {
+        $this->username = $username;
+    }
+
+    public function getStatus(): AdminUserStatusEnum
+    {
+        return $this->status;
+    }
+
+    public function setStatus(AdminUserStatusEnum $status): void
+    {
+        $this->status = $status;
     }
 }

--- a/tests/Application/src/Enum/AdminUserStatusEnum.php
+++ b/tests/Application/src/Enum/AdminUserStatusEnum.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+enum AdminUserStatusEnum: string implements TranslatableInterface
+{
+    case Active = 'active';
+    case Inactive = 'inactive';
+    case Banned = 'banned';
+
+    public function trans(TranslatorInterface $translator, ?string $locale = null): string
+    {
+        return match ($this) {
+            self::Active => $translator->trans('enum.status.active', locale: $locale),
+            self::Inactive => $translator->trans('enum.status.inactive', locale: $locale),
+            self::Banned => $translator->trans('enum.status.banned', locale: $locale),
+        };
+    }
+}

--- a/tests/Application/src/Grid/AdminUserGrid.php
+++ b/tests/Application/src/Grid/AdminUserGrid.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App\Grid;
+
+use App\Entity\AdminUser;
+use App\Enum\AdminUserStatusEnum;
+use Sylius\Bundle\GridBundle\Builder\Field\EnumField;
+use Sylius\Bundle\GridBundle\Builder\Field\StringField;
+use Sylius\Bundle\GridBundle\Builder\Filter\EnumFilter;
+use Sylius\Bundle\GridBundle\Builder\Filter\Filter;
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
+use Sylius\Bundle\GridBundle\Grid\AbstractGrid;
+use Sylius\Component\Grid\Attribute\AsGrid;
+
+#[AsGrid(resourceClass: AdminUser::class, name: 'app_admin_user')]
+final class AdminUserGrid extends AbstractGrid
+{
+    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    {
+        $gridBuilder
+            ->addFilter(Filter::create('name', 'string'))
+            ->addFilter(EnumFilter::create('status', AdminUserStatusEnum::class))
+            ->addField(
+                StringField::create('username')
+                    ->setLabel('Username')
+                    ->setSortable(true),
+            )
+            ->addField(
+                EnumField::create('status')
+                    ->setLabel('Status'),
+            )
+            ->setLimits([10, 5, 15, 100])
+        ;
+    }
+}

--- a/tests/Application/templates/grid/filter/enum.html.twig
+++ b/tests/Application/templates/grid/filter/enum.html.twig
@@ -1,0 +1,1 @@
+{{ form_row(form, { 'label': filter.label, hideOptionalLabel: true }) }}


### PR DESCRIPTION
I've added a EnumField type to render database enum values correctly as an Enum can't be converted to string (for the string type). In this field I've used the same logic as in the Symfony Enum form type, eg. if it's an translatable enum, translate it first otherwise just render the ->value of the enum

The same goes for the filter where we use the Symfony Enum form type to render the filter, the only config it needs is the enum class used to render the options.