### PR TITLE
Introduce AsField attribute to define field type

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -33,6 +33,11 @@ parameters:
           identifier: method.nonObject
           count: 166
           path: src/Bundle/DependencyInjection/Configuration.php
+        # Symfony Dependency Injection Reflector
+        - message: '#^Parameter \#2 \$configurator of method Symfony\\Component\\DependencyInjection\\ContainerBuilder\:\:registerAttributeForAutoconfiguration\(\)#'
+          identifier: argument.type
+          count: 2
+          path: src/Bundle/DependencyInjection/SyliusGridExtension.php
         # Symfony 8 without Doctrine PHPCR-ODM
         - message: '#^Method Sylius\\Bundle\\GridBundle\\Doctrine\\DataSourceInterface\:\:getQueryBuilder\(\) has invalid return type Doctrine\\ODM\\PHPCR\\Query\\Builder\\QueryBuilder\.$#'
           identifier: class.notFound

--- a/src/Bundle/DependencyInjection/SyliusGridExtension.php
+++ b/src/Bundle/DependencyInjection/SyliusGridExtension.php
@@ -19,6 +19,7 @@ use Sylius\Bundle\CurrencyBundle\SyliusCurrencyBundle;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 use Sylius\Bundle\GridBundle\SyliusGridBundle;
 use Sylius\Component\Grid\Annotation\AsGridFieldCallableService;
+use Sylius\Component\Grid\Attribute\AsField;
 use Sylius\Component\Grid\Attribute\AsFilter;
 use Sylius\Component\Grid\Data\DataProviderInterface;
 use Sylius\Component\Grid\Filtering\ConfigurableFilterInterface;
@@ -84,16 +85,20 @@ final class SyliusGridExtension extends Extension
 
         $container->registerAttributeForAutoconfiguration(
             AsFilter::class,
-            static function (ChildDefinition $definition, AsFilter $attribute, \Reflector $reflector): void {
-                // Helps to avoid issues with psalm
-                if (!$reflector instanceof \ReflectionClass) {
-                    return;
-                }
-
+            static function (ChildDefinition $definition, AsFilter $attribute, \ReflectionClass $reflector): void {
                 $definition->addTag(AsFilter::SERVICE_TAG, [
                     'type' => $attribute->type ?? $reflector->getName(),
                     'form_type' => $attribute->formType,
                     'template' => $attribute->template,
+                ]);
+            },
+        );
+
+        $container->registerAttributeForAutoconfiguration(
+            AsField::class,
+            static function (ChildDefinition $definition, AsField $attribute, \ReflectionClass $reflector): void {
+                $definition->addTag(AsField::SERVICE_TAG, [
+                    'type' => $attribute->type ?? $reflector->getName(),
                 ]);
             },
         );

--- a/src/Bundle/Tests/Integration/CustomFiltersTest.php
+++ b/src/Bundle/Tests/Integration/CustomFiltersTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Integration;
+
+use App\Field\FirstCustomField;
+use Sylius\Component\Registry\ServiceRegistry;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class CustomFiltersTest extends KernelTestCase
+{
+    public function testItRegistersCustomFilters(): void
+    {
+        $container = static::getContainer();
+
+        /** @var ServiceRegistry $fieldRegistry */
+        $fieldRegistry = $container->get('sylius.registry.grid_field');
+
+        self::assertTrue($fieldRegistry->has(FirstCustomField::class));
+        self::assertTrue($fieldRegistry->has('custom_two'));
+    }
+}

--- a/src/Component/Attribute/AsField.php
+++ b/src/Component/Attribute/AsField.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class AsField
+{
+    public const SERVICE_TAG = 'sylius.grid_field';
+
+    public function __construct(
+        public readonly ?string $type = null,
+    ) {
+    }
+}

--- a/tests/Application/src/Field/FirstCustomField.php
+++ b/tests/Application/src/Field/FirstCustomField.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App\Field;
+
+use Sylius\Component\Grid\Attribute\AsField;
+use Sylius\Component\Grid\Definition\Field;
+use Sylius\Component\Grid\FieldTypes\FieldTypeInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+#[AsField]
+class FirstCustomField implements FieldTypeInterface
+{
+    public function render(Field $field, $data, array $options): string
+    {
+        return '';
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+    }
+}

--- a/tests/Application/src/Field/SecondCustomField.php
+++ b/tests/Application/src/Field/SecondCustomField.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App\Field;
+
+use Sylius\Component\Grid\Attribute\AsField;
+use Sylius\Component\Grid\Definition\Field;
+use Sylius\Component\Grid\FieldTypes\FieldTypeInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+#[AsField(type: 'custom_two')]
+class SecondCustomField implements FieldTypeInterface
+{
+    public function render(Field $field, $data, array $options): string
+    {
+        return '';
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+    }
+}


### PR DESCRIPTION
With this feature, we'll be able to define custom field types.

**As an example:**
```php
#[AsField]
final class DateTimeField implements FieldTypeInterface
{
    public function __construct(
        private readonly TwigFieldType $twigFieldType,
    ) {
    }

    public function render(Field $field, $data, array $options): string
    {
        return $this->twigFieldType->render($field, $data, $options);
    }

    public function configureOptions(OptionsResolver $resolver): void
    {
        $this->twigFieldType->configureOptions($resolver);

        $resolver->setDefaults([
            'template' => 'shared/grid/field/datetime.html.twig',
            'vars' => [
                'th_class' => 'w-1 text-center',
            ],
        ]);
    }
}
```