### PR TITLE
Add mixed type declaration to FieldTypeInterface::render() $data parameter

### DIFF
--- a/src/Bundle/FieldTypes/TwigFieldType.php
+++ b/src/Bundle/FieldTypes/TwigFieldType.php
@@ -31,7 +31,7 @@ final class TwigFieldType implements FieldTypeInterface
         $this->twig = $twig;
     }
 
-    public function render(Field $field, $data, array $options): string
+    public function render(Field $field, mixed $data, array $options): string
     {
         if ('.' !== $field->getPath()) {
             $data = $this->dataExtractor->get($field, $data);

--- a/src/Component/FieldTypes/CallableFieldType.php
+++ b/src/Component/FieldTypes/CallableFieldType.php
@@ -27,7 +27,7 @@ final class CallableFieldType implements FieldTypeInterface
     ) {
     }
 
-    public function render(Field $field, $data, array $options): string
+    public function render(Field $field, mixed $data, array $options): string
     {
         if (isset($options['callable']) === isset($options['service'])) {
             throw new \RuntimeException('Exactly one of the "callable" or "service" options must be defined.');

--- a/src/Component/FieldTypes/DatetimeFieldType.php
+++ b/src/Component/FieldTypes/DatetimeFieldType.php
@@ -32,7 +32,7 @@ final class DatetimeFieldType implements FieldTypeInterface
     /**
      * @throws \InvalidArgumentException
      */
-    public function render(Field $field, $data, array $options): string
+    public function render(Field $field, mixed $data, array $options): string
     {
         $value = $this->dataExtractor->get($field, $data);
         if (null === $value) {

--- a/src/Component/FieldTypes/EnumFieldType.php
+++ b/src/Component/FieldTypes/EnumFieldType.php
@@ -29,7 +29,7 @@ final class EnumFieldType implements FieldTypeInterface
     ) {
     }
 
-    public function render(Field $field, $data, array $options): string
+    public function render(Field $field, mixed $data, array $options): string
     {
         $enum = $this->dataExtractor->get($field, $data);
 

--- a/src/Component/FieldTypes/FieldTypeInterface.php
+++ b/src/Component/FieldTypes/FieldTypeInterface.php
@@ -22,12 +22,11 @@ interface FieldTypeInterface
      * Return a HTML representation of the $field using the given $data and
      * $options.
      *
-     * @param mixed $data
      * @param array<string, mixed> $options
      *
      * @return string
      */
-    public function render(Field $field, $data, array $options);
+    public function render(Field $field, mixed $data, array $options);
 
     /**
      * Configure options for this field type.

--- a/src/Component/FieldTypes/StringFieldType.php
+++ b/src/Component/FieldTypes/StringFieldType.php
@@ -26,7 +26,7 @@ final class StringFieldType implements FieldTypeInterface
         $this->dataExtractor = $dataExtractor;
     }
 
-    public function render(Field $field, $data, array $options): string
+    public function render(Field $field, mixed $data, array $options): string
     {
         $value = $this->dataExtractor->get($field, $data);
 

--- a/tests/Application/src/FieldTypes/FooType.php
+++ b/tests/Application/src/FieldTypes/FooType.php
@@ -19,7 +19,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class FooType implements FieldTypeInterface
 {
-    public function render(Field $field, $data, array $options): string
+    public function render(Field $field, mixed $data, array $options): string
     {
         return '';
     }


### PR DESCRIPTION
Add mixed type declaration to FieldTypeInterface::render() $data parameter

- Add explicit 'mixed' type hint to $data parameter in FieldTypeInterface::render()
- Update all implementations: StringFieldType, DatetimeFieldType, EnumFieldType, CallableFieldType, TwigFieldType
- Update test implementation: FooType
- Improves type safety and IDE support while maintaining backward compatibility
- Aligns method signatures with modern PHP standards (PHP 8.1+)

BC-break tests :
 - https://3v4l.org/cLXcD
 - https://3v4l.org/VLkT1
 - https://3v4l.org/epTlh

Fixes #423