### PR TITLE
Improve PHPDoc for $options parameter in FieldTypeInterface::render()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -667,12 +667,6 @@ parameters:
 			path: src/Bundle/Doctrine/ORM/Driver.php
 
 		-
-			message: '#^Method Sylius\\Bundle\\GridBundle\\FieldTypes\\TwigFieldType\:\:render\(\) has parameter \$options with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Bundle/FieldTypes/TwigFieldType.php
-
-		-
 			message: '#^Parameter \#1 \$name of method Twig\\Environment\:\:render\(\) expects string\|Twig\\TemplateWrapper, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -1417,12 +1411,6 @@ parameters:
 			path: src/Component/FieldTypes/CallableFieldType.php
 
 		-
-			message: '#^Method Sylius\\Component\\Grid\\FieldTypes\\CallableFieldType\:\:render\(\) has parameter \$options with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Component/FieldTypes/CallableFieldType.php
-
-		-
 			message: '#^Parameter \#1 \$id of method Psr\\Container\\ContainerInterface\:\:get\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -1447,12 +1435,6 @@ parameters:
 			path: src/Component/FieldTypes/CallableFieldType.php
 
 		-
-			message: '#^Method Sylius\\Component\\Grid\\FieldTypes\\DatetimeFieldType\:\:render\(\) has parameter \$options with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Component/FieldTypes/DatetimeFieldType.php
-
-		-
 			message: '#^Parameter \#1 \$format of method DateTime\:\:format\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -1463,24 +1445,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/Component/FieldTypes/DatetimeFieldType.php
-
-		-
-			message: '#^Method Sylius\\Component\\Grid\\FieldTypes\\EnumFieldType\:\:render\(\) has parameter \$options with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Component/FieldTypes/EnumFieldType.php
-
-		-
-			message: '#^Method Sylius\\Component\\Grid\\FieldTypes\\FieldTypeInterface\:\:render\(\) has parameter \$options with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Component/FieldTypes/FieldTypeInterface.php
-
-		-
-			message: '#^Method Sylius\\Component\\Grid\\FieldTypes\\StringFieldType\:\:render\(\) has parameter \$options with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Component/FieldTypes/StringFieldType.php
 
 		-
 			message: '#^Method Sylius\\Component\\Grid\\Filter\\BooleanFilter\:\:apply\(\) has parameter \$options with no value type specified in iterable type array\.$#'

--- a/src/Component/FieldTypes/FieldTypeInterface.php
+++ b/src/Component/FieldTypes/FieldTypeInterface.php
@@ -23,6 +23,7 @@ interface FieldTypeInterface
      * $options.
      *
      * @param mixed $data
+     * @param array<string, mixed> $options
      *
      * @return string
      */


### PR DESCRIPTION
Fixes #427

- Updated PHPDoc for the $options parameter in FieldTypeInterface::render() method from 'array' to 'array<string, mixed>' for improved type clarity
- Removed PHPStan baseline entries for FieldType render() methods that are now properly typed:
  - TwigFieldType::render()
  - CallableFieldType::render()
  - DatetimeFieldType::render()
  - EnumFieldType::render()
  - FieldTypeInterface::render()
  - StringFieldType::render()

This change improves code quality, contributor experience, and helps static analysis tools infer the expected array structure.