### PR TITLE
PHPStan configuration enhancements with Symfony extension support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,9 +65,11 @@
         "matthiasnoback/symfony-dependency-injection-test": "^5.1",
         "pagerfanta/pagerfanta": "^3.7 || ^4.0",
         "pamil/phpspec-skip-example-extension": "^4.2",
+        "phpstan/extension-installer": "^1.4",
         "phpspec/phpspec": "^7.2",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/phpstan-symfony": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0",
         "phpunit/phpunit": "^9.5",
         "sylius-labs/coding-standard": "^4.0",
@@ -81,9 +83,7 @@
         "symfony/twig-bundle": "^6.4 || ^7.2",
         "twig/twig": "^2.12 || ^3.0",
         "rector/rector": "^2.0",
-        "rector/custom-phpspec-to-phpunit": "^0.6.2",
-        "phpstan/phpstan-symfony": "^2.0",
-        "phpstan/extension-installer": "^1.4"
+        "rector/custom-phpspec-to-phpunit": "^0.6.2"
     },
     "suggest": {
         "sylius/currency-bundle": "^1.7"
@@ -111,7 +111,8 @@
     "config": {
         "allow-plugins": {
             "symfony/flex": true,
-            "dealerdirect/phpcodesniffer-composer-installer": false
+            "dealerdirect/phpcodesniffer-composer-installer": false,
+            "phpstan/extension-installer": true
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,9 @@
         "symfony/twig-bundle": "^6.4 || ^7.2",
         "twig/twig": "^2.12 || ^3.0",
         "rector/rector": "^2.0",
-        "rector/custom-phpspec-to-phpunit": "^0.6.2"
+        "rector/custom-phpspec-to-phpunit": "^0.6.2",
+        "phpstan/phpstan-symfony": "^2.0",
+        "phpstan/extension-installer": "^1.4"
     },
     "suggest": {
         "sylius/currency-bundle": "^1.7"

--- a/composer.json
+++ b/composer.json
@@ -118,7 +118,7 @@
         "analyse": [
             "@composer validate --strict",
             "vendor/bin/ecs check",
-            "vendor/bin/phpstan analyse --ansi -l max src"
+            "vendor/bin/phpstan analyse --ansi"
         ],
         "fix": [
             "vendor/bin/ecs check --fix"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,37 +1,39 @@
 includes:
     - phpstan-baseline.neon
-    - vendor/phpstan/phpstan-webmozart-assert/extension.neon
-    - vendor/phpstan/phpstan-phpunit/extension.neon
-    - vendor/phpstan/phpstan-phpunit/rules.neon
 
 parameters:
     reportUnmatchedIgnoredErrors: false
     treatPhpDocTypesAsCertain: false
 
+    level: max
+
+    paths:
+        - src
+
     excludePaths:
-        - %currentWorkingDirectory%/src/Bundle/Config/GridConfigInterface.php
-        - %currentWorkingDirectory%/src/Bundle/Doctrine/PHPCRODM/*
-        - %currentWorkingDirectory%/src/Bundle/Doctrine/ORM/ExpressionBuilder.php
-        - %currentWorkingDirectory%/src/Bundle/DependencyInjection/Configuration.php
-        - %currentWorkingDirectory%/src/Bundle/Form/DataTransformer/DateTimeFilterTransformer.php
-        - %currentWorkingDirectory%/src/Bundle/Maker/MakeGrid.php
-        - %currentWorkingDirectory%/src/Bundle/Registry/GridRegistry.php
-        - %currentWorkingDirectory%/src/Bundle/Renderer/TwigGridRenderer.php
-        - %currentWorkingDirectory%/src/Bundle/Resources/*
-        - %currentWorkingDirectory%/src/Bundle/spec/*
-        - %currentWorkingDirectory%/src/Bundle/Tests/*
-        - %currentWorkingDirectory%/src/Component/DataExtractor/PropertyAccessDataExtractor.php
-        - %currentWorkingDirectory%/src/Component/Definition/Filter.php
-        - %currentWorkingDirectory%/src/Component/Filter/DateFilter.php
-        - %currentWorkingDirectory%/src/Component/Filter/MoneyFilter.php
-        - %currentWorkingDirectory%/src/Component/Filter/NumericRangeFilter.php
-        - %currentWorkingDirectory%/src/Component/Filter/StringFilter.php
-        - %currentWorkingDirectory%/src/Component/Filtering/FiltersCriteriaResolver.php
-        - %currentWorkingDirectory%/src/Component/Sorting/Sorter.php
-        - %currentWorkingDirectory%/src/Component/View/GridView.php
-        - %currentWorkingDirectory%/src/Component/spec/*
-        - %currentWorkingDirectory%/src/Component/Tests/*
-        - %currentWorkingDirectory%/src/Component/vendor/*
+        - src/Bundle/Config/GridConfigInterface.php
+        - src/Bundle/Doctrine/PHPCRODM/*
+        - src/Bundle/Doctrine/ORM/ExpressionBuilder.php
+        - src/Bundle/DependencyInjection/Configuration.php
+        - src/Bundle/Form/DataTransformer/DateTimeFilterTransformer.php
+        - src/Bundle/Maker/MakeGrid.php
+        - src/Bundle/Registry/GridRegistry.php
+        - src/Bundle/Renderer/TwigGridRenderer.php
+        - src/Bundle/Resources/*
+        - src/Bundle/spec/*
+        - src/Bundle/Tests/*
+        - src/Component/DataExtractor/PropertyAccessDataExtractor.php
+        - src/Component/Definition/Filter.php
+        - src/Component/Filter/DateFilter.php
+        - src/Component/Filter/MoneyFilter.php
+        - src/Component/Filter/NumericRangeFilter.php
+        - src/Component/Filter/StringFilter.php
+        - src/Component/Filtering/FiltersCriteriaResolver.php
+        - src/Component/Sorting/Sorter.php
+        - src/Component/View/GridView.php
+        - src/Component/spec/*
+        - src/Component/Tests/*
+        - src/Component/vendor/*
 
     ignoreErrors:
         - '/Cannot cast mixed to int./'

--- a/src/Bundle/Form/Type/Filter/BooleanFilterType.php
+++ b/src/Bundle/Form/Type/Filter/BooleanFilterType.php
@@ -18,6 +18,9 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<mixed>
+ */
 final class BooleanFilterType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Bundle/Form/Type/Filter/DateFilterType.php
+++ b/src/Bundle/Form/Type/Filter/DateFilterType.php
@@ -19,6 +19,9 @@ use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<mixed>
+ */
 final class DateFilterType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void

--- a/src/Bundle/Form/Type/Filter/EntityFilterType.php
+++ b/src/Bundle/Form/Type/Filter/EntityFilterType.php
@@ -17,6 +17,9 @@ use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<mixed>
+ */
 final class EntityFilterType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Bundle/Form/Type/Filter/EnumFilterType.php
+++ b/src/Bundle/Form/Type/Filter/EnumFilterType.php
@@ -17,6 +17,9 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\EnumType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<mixed>
+ */
 final class EnumFilterType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Bundle/Form/Type/Filter/ExistsFilterType.php
+++ b/src/Bundle/Form/Type/Filter/ExistsFilterType.php
@@ -18,6 +18,9 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<mixed>
+ */
 final class ExistsFilterType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Bundle/Form/Type/Filter/MoneyFilterType.php
+++ b/src/Bundle/Form/Type/Filter/MoneyFilterType.php
@@ -22,6 +22,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 \trigger_deprecation('sylius/grid-bundle', '1.8', '%s is deprecated, replace it with your own implementation.', MoneyFilterType::class);
 
+/**
+ * @extends AbstractType<mixed>
+ */
 final class MoneyFilterType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void

--- a/src/Bundle/Form/Type/Filter/NumericRangeFilterType.php
+++ b/src/Bundle/Form/Type/Filter/NumericRangeFilterType.php
@@ -19,6 +19,9 @@ use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<mixed>
+ */
 final class NumericRangeFilterType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void

--- a/src/Bundle/Form/Type/Filter/SelectFilterType.php
+++ b/src/Bundle/Form/Type/Filter/SelectFilterType.php
@@ -17,6 +17,9 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<mixed>
+ */
 final class SelectFilterType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Bundle/Form/Type/Filter/StringFilterType.php
+++ b/src/Bundle/Form/Type/Filter/StringFilterType.php
@@ -20,6 +20,9 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<mixed>
+ */
 final class StringFilterType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void


### PR DESCRIPTION
This pull request enhances the PHPStan configuration by adding Symfony-specific static analysis support, improving configuration structure, and adding missing generic type annotations to Form Type classes.

**Configuration updates:**

* Added `phpstan/phpstan-symfony` extension for better Symfony-specific static analysis capabilities, including improved understanding of Symfony Form components, dependency injection, and framework-specific patterns
* Added `phpstan/extension-installer` to automatically discover and load PHPStan extensions, eliminating the need for manual extension includes in the configuration file
* Configured explicit `paths` parameter to analyze only the `src` directory, making the analysis scope clear and explicit
* Set PHPStan analysis `level` to `max` for the most comprehensive static analysis coverage
* Simplified `excludePaths` by removing the `%currentWorkingDirectory%` prefix, making paths more concise and readable
* Removed manual extension includes (`phpstan-webmozart-assert`, `phpstan-phpunit`) from `phpstan.neon.dist` as they are now automatically loaded by `extension-installer`

**Code quality improvements:**

* Added missing `@extends AbstractType<mixed>` PHPDoc annotations to all Filter Type classes:
  - `BooleanFilterType`
  - `DateFilterType`
  - `EntityFilterType`
  - `EnumFilterType`
  - `ExistsFilterType`
  - `MoneyFilterType`
  - `NumericRangeFilterType`
  - `SelectFilterType`
  - `StringFilterType`
* These annotations help PHPStan understand the generic type inheritance from Symfony's `AbstractType`, improving type inference and reducing false positives