### PR TITLE
PHPStan baseline cleanup (first batch)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -893,3 +893,9 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Component/Provider/ChainProvider.php
+
+		-
+			message: '#^Parameter \#1 \$objectOrArray of method Symfony\\Component\\PropertyAccess\\PropertyAccessorInterface\:\:getValue\(\) expects array\|object, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Component/DataExtractor/PropertyAccessDataExtractor.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -469,12 +469,6 @@ parameters:
 			path: src/Component/Definition/ArrayToDefinitionConverter.php
 
 		-
-			message: '#^Parameter \#1 \$formOptions of method Sylius\\Component\\Grid\\Definition\\Filter\:\:setFormOptions\(\) expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Component/Definition/ArrayToDefinitionConverter.php
-
-		-
 			message: '#^Parameter \#1 \$icon of method Sylius\\Component\\Grid\\Definition\\Action\:\:setIcon\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -529,18 +523,6 @@ parameters:
 			path: src/Component/Definition/ArrayToDefinitionConverter.php
 
 		-
-			message: '#^Parameter \#1 \$options of method Sylius\\Component\\Grid\\Definition\\Field\:\:setOptions\(\) expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Component/Definition/ArrayToDefinitionConverter.php
-
-		-
-			message: '#^Parameter \#1 \$options of method Sylius\\Component\\Grid\\Definition\\Filter\:\:setOptions\(\) expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Component/Definition/ArrayToDefinitionConverter.php
-
-		-
 			message: '#^Parameter \#1 \$path of method Sylius\\Component\\Grid\\Definition\\Field\:\:setPath\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -572,12 +554,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$sortable of method Sylius\\Component\\Grid\\Definition\\Field\:\:setSortable\(\) expects string\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Component/Definition/ArrayToDefinitionConverter.php
-
-		-
-			message: '#^Parameter \#1 \$sorting of method Sylius\\Component\\Grid\\Definition\\Grid\:\:setSorting\(\) expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Component/Definition/ArrayToDefinitionConverter.php
@@ -643,24 +619,6 @@ parameters:
 			path: src/Component/Definition/ArrayToDefinitionConverter.php
 
 		-
-			message: '#^Method Sylius\\Component\\Grid\\Definition\\Field\:\:getOptions\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Component/Definition/Field.php
-
-		-
-			message: '#^Method Sylius\\Component\\Grid\\Definition\\Field\:\:setOptions\(\) has parameter \$options with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Component/Definition/Field.php
-
-		-
-			message: '#^Property Sylius\\Component\\Grid\\Definition\\Field\:\:\$options type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Component/Definition/Field.php
-
-		-
 			message: '#^Method Sylius\\Component\\Grid\\Definition\\Grid\:\:getActionGroup\(\) should return Sylius\\Component\\Grid\\Definition\\ActionGroup but returns mixed\.$#'
 			identifier: return.type
 			count: 1
@@ -679,37 +637,7 @@ parameters:
 			path: src/Component/Definition/Grid.php
 
 		-
-			message: '#^Method Sylius\\Component\\Grid\\Definition\\Grid\:\:getField\(\) should return Sylius\\Component\\Grid\\Definition\\Field but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Component/Definition/Grid.php
-
-		-
-			message: '#^Method Sylius\\Component\\Grid\\Definition\\Grid\:\:getFields\(\) should return array\<Sylius\\Component\\Grid\\Definition\\Field\> but returns array\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Component/Definition/Grid.php
-
-		-
-			message: '#^Method Sylius\\Component\\Grid\\Definition\\Grid\:\:getFilter\(\) should return Sylius\\Component\\Grid\\Definition\\Filter but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Component/Definition/Grid.php
-
-		-
-			message: '#^Method Sylius\\Component\\Grid\\Definition\\Grid\:\:getFilters\(\) should return array\<Sylius\\Component\\Grid\\Definition\\Filter\> but returns array\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Component/Definition/Grid.php
-
-		-
 			message: '#^Method Sylius\\Component\\Grid\\Definition\\Grid\:\:getLimits\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Component/Definition/Grid.php
-
-		-
-			message: '#^Method Sylius\\Component\\Grid\\Definition\\Grid\:\:getSorting\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Component/Definition/Grid.php
@@ -721,37 +649,13 @@ parameters:
 			path: src/Component/Definition/Grid.php
 
 		-
-			message: '#^Method Sylius\\Component\\Grid\\Definition\\Grid\:\:setSorting\(\) has parameter \$sorting with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Component/Definition/Grid.php
-
-		-
 			message: '#^Property Sylius\\Component\\Grid\\Definition\\Grid\:\:\$actionGroups type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Component/Definition/Grid.php
 
 		-
-			message: '#^Property Sylius\\Component\\Grid\\Definition\\Grid\:\:\$fields type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Component/Definition/Grid.php
-
-		-
-			message: '#^Property Sylius\\Component\\Grid\\Definition\\Grid\:\:\$filters type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Component/Definition/Grid.php
-
-		-
 			message: '#^Property Sylius\\Component\\Grid\\Definition\\Grid\:\:\$limits type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Component/Definition/Grid.php
-
-		-
-			message: '#^Property Sylius\\Component\\Grid\\Definition\\Grid\:\:\$sorting type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Component/Definition/Grid.php
@@ -851,12 +755,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/Component/Filter/SelectFilter.php
-
-		-
-			message: '#^Method Sylius\\Component\\Grid\\Filtering\\FiltersCriteriaResolverInterface\:\:getCriteria\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Component/Filtering/FiltersCriteriaResolverInterface.php
 
 		-
 			message: '#^Method Sylius\\Component\\Grid\\Parameters\:\:all\(\) return type has no value type specified in iterable type array\.$#'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -899,3 +899,9 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/Component/DataExtractor/PropertyAccessDataExtractor.php
+
+		-
+			message: '#^Method Sylius\\Component\\Grid\\Definition\\Filter\:\:setCriteria\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Component/Definition/Filter.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -367,6 +367,12 @@ parameters:
 			path: src/Component/Configuration/GridConfigurationSortingHandler.php
 
 		-
+			message: '#^Possibly invalid array key type mixed\.$#'
+			identifier: offsetAccess.invalidOffset
+			count: 2
+			path: src/Component/Configuration/GridConfigurationSortingHandler.php
+
+		-
 			message: '#^Parameter \#1 \$array of static method Webmozart\\Assert\\Assert\:\:keyExists\(\) expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 1

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,7 +15,6 @@ parameters:
         - src/Bundle/Resources/*
         - src/Bundle/spec/*
         - src/Bundle/Tests/*
-        - src/Component/DataExtractor/PropertyAccessDataExtractor.php
         - src/Component/Definition/Filter.php
         - src/Component/Filter/DateFilter.php
         - src/Component/Filter/MoneyFilter.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,7 +12,6 @@ parameters:
 
     excludePaths:
         - src/Bundle/Doctrine/PHPCRODM/*
-        - src/Bundle/Maker/MakeGrid.php
         - src/Bundle/Registry/GridRegistry.php
         - src/Bundle/Renderer/TwigGridRenderer.php
         - src/Bundle/Resources/*

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,7 +12,6 @@ parameters:
 
     excludePaths:
         - src/Bundle/Doctrine/PHPCRODM/*
-        - src/Bundle/Renderer/TwigGridRenderer.php
         - src/Bundle/Resources/*
         - src/Bundle/spec/*
         - src/Bundle/Tests/*

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,7 +15,6 @@ parameters:
         - src/Bundle/Resources/*
         - src/Bundle/spec/*
         - src/Bundle/Tests/*
-        - src/Component/Filter/DateFilter.php
         - src/Component/Filter/MoneyFilter.php
         - src/Component/Filter/NumericRangeFilter.php
         - src/Component/Filter/StringFilter.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,7 +15,6 @@ parameters:
         - src/Bundle/Resources/*
         - src/Bundle/spec/*
         - src/Bundle/Tests/*
-        - src/Component/Filter/StringFilter.php
         - src/Component/Filtering/FiltersCriteriaResolver.php
         - src/Component/Sorting/Sorter.php
         - src/Component/View/GridView.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,7 +15,6 @@ parameters:
         - src/Bundle/Resources/*
         - src/Bundle/spec/*
         - src/Bundle/Tests/*
-        - src/Component/Definition/Filter.php
         - src/Component/Filter/DateFilter.php
         - src/Component/Filter/MoneyFilter.php
         - src/Component/Filter/NumericRangeFilter.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,7 +12,6 @@ parameters:
 
     excludePaths:
         - src/Bundle/Doctrine/PHPCRODM/*
-        - src/Bundle/Registry/GridRegistry.php
         - src/Bundle/Renderer/TwigGridRenderer.php
         - src/Bundle/Resources/*
         - src/Bundle/spec/*

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,7 +15,6 @@ parameters:
         - src/Bundle/Resources/*
         - src/Bundle/spec/*
         - src/Bundle/Tests/*
-        - src/Component/Sorting/Sorter.php
         - src/Component/View/GridView.php
         - src/Component/spec/*
         - src/Component/Tests/*

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,8 +15,6 @@ parameters:
         - src/Bundle/Resources/*
         - src/Bundle/spec/*
         - src/Bundle/Tests/*
-        - src/Component/Filter/MoneyFilter.php
-        - src/Component/Filter/NumericRangeFilter.php
         - src/Component/Filter/StringFilter.php
         - src/Component/Filtering/FiltersCriteriaResolver.php
         - src/Component/Sorting/Sorter.php
@@ -24,6 +22,8 @@ parameters:
         - src/Component/spec/*
         - src/Component/Tests/*
         - src/Component/vendor/*
+        # deprecated
+        - src/Component/Filter/MoneyFilter.php
 
     ignoreErrors:
         - '/Cannot cast mixed to int./'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,7 +15,6 @@ parameters:
         - src/Bundle/Resources/*
         - src/Bundle/spec/*
         - src/Bundle/Tests/*
-        - src/Component/View/GridView.php
         - src/Component/spec/*
         - src/Component/Tests/*
         - src/Component/vendor/*

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,7 +15,6 @@ parameters:
         - src/Bundle/Resources/*
         - src/Bundle/spec/*
         - src/Bundle/Tests/*
-        - src/Component/Filtering/FiltersCriteriaResolver.php
         - src/Component/Sorting/Sorter.php
         - src/Component/View/GridView.php
         - src/Component/spec/*

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,10 +11,7 @@ parameters:
         - src
 
     excludePaths:
-        - src/Bundle/Config/GridConfigInterface.php
         - src/Bundle/Doctrine/PHPCRODM/*
-        - src/Bundle/Doctrine/ORM/ExpressionBuilder.php
-        - src/Bundle/Form/DataTransformer/DateTimeFilterTransformer.php
         - src/Bundle/Maker/MakeGrid.php
         - src/Bundle/Registry/GridRegistry.php
         - src/Bundle/Renderer/TwigGridRenderer.php

--- a/src/Bundle/Doctrine/ORM/ExpressionBuilder.php
+++ b/src/Bundle/Doctrine/ORM/ExpressionBuilder.php
@@ -13,9 +13,12 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\GridBundle\Doctrine\ORM;
 
+use Doctrine\ORM\Query\Expr\Andx;
 use Doctrine\ORM\Query\Expr\Comparison;
 use Doctrine\ORM\Query\Expr\From;
+use Doctrine\ORM\Query\Expr\Func;
 use Doctrine\ORM\Query\Expr\Join;
+use Doctrine\ORM\Query\Expr\Orx;
 use Doctrine\ORM\QueryBuilder;
 use Sylius\Component\Grid\Data\MemberOfAwareExpressionBuilderInterface;
 
@@ -28,11 +31,17 @@ final class ExpressionBuilder implements MemberOfAwareExpressionBuilderInterface
         $this->queryBuilder = $queryBuilder;
     }
 
+    /**
+     * @param Comparison|Func|Andx|Orx|string ...$expressions
+     */
     public function andX(...$expressions)
     {
         return $this->queryBuilder->expr()->andX(...$expressions);
     }
 
+    /**
+     * @param Comparison|Func|Andx|Orx|string ...$expressions
+     */
     public function orX(...$expressions)
     {
         return $this->queryBuilder->expr()->orX(...$expressions);
@@ -97,6 +106,9 @@ final class ExpressionBuilder implements MemberOfAwareExpressionBuilderInterface
         return $this->queryBuilder->expr()->gte($this->resolveFieldByAddingJoins($field), ':' . $parameterName);
     }
 
+    /**
+     * @param string $value
+     */
     public function memberOf($value, string $field)
     {
         $field = $this->adjustField($field);
@@ -210,8 +222,9 @@ final class ExpressionBuilder implements MemberOfAwareExpressionBuilderInterface
             );
             $rootAndAssociationField = sprintf('%s.%s', $rootField, $associationField);
 
-            /** @var Join[] $joins */
-            $joins = array_merge([], ...array_values($this->queryBuilder->getDQLPart('join')));
+            /** @var array<Join[]> $joinDQLPart */
+            $joinDQLPart = $this->queryBuilder->getDQLPart('join');
+            $joins = array_merge([], ...array_values($joinDQLPart));
             foreach ($joins as $join) {
                 if ($join->getJoin() === $rootAndAssociationField) {
                     $field = sprintf('%s.%s', (string) $join->getAlias(), $remainder);
@@ -248,6 +261,11 @@ final class ExpressionBuilder implements MemberOfAwareExpressionBuilderInterface
      * title => [book.title, App\Book]
      * au => [book.author, App\Book]
      * au.name => [book.author.name, App\Book]
+     *
+     * @return array{
+     *     string,
+     *     string
+     * }
      */
     private function getFieldDetails(string $field): array
     {
@@ -256,8 +274,9 @@ final class ExpressionBuilder implements MemberOfAwareExpressionBuilderInterface
             $field = sprintf('%s.%s', $this->queryBuilder->getRootAliases()[0], $field);
         }
 
-        /** @var Join[] $joins */
-        $joins = array_merge([], ...array_values($this->queryBuilder->getDQLPart('join')));
+        /** @var array<Join[]> $joinDQLPart */
+        $joinDQLPart = $this->queryBuilder->getDQLPart('join');
+        $joins = array_merge([], ...array_values($joinDQLPart));
         while ($explodedField = explode('.', $field, 2)) {
             $rootField = $explodedField[0];
             $remainder = $explodedField[1] ?? '';

--- a/src/Bundle/Form/DataTransformer/DateTimeFilterTransformer.php
+++ b/src/Bundle/Form/DataTransformer/DateTimeFilterTransformer.php
@@ -16,6 +16,9 @@ namespace Sylius\Bundle\GridBundle\Form\DataTransformer;
 use Symfony\Component\Form\DataTransformerInterface;
 use Webmozart\Assert\Assert;
 
+/**
+ * @implements DataTransformerInterface<array<string, mixed>, array<string, mixed>>
+ */
 final class DateTimeFilterTransformer implements DataTransformerInterface
 {
     /** @var array<string, array{hour: string, minute: string}> */
@@ -24,31 +27,32 @@ final class DateTimeFilterTransformer implements DataTransformerInterface
         'to' => ['hour' => '23', 'minute' => '59'],
     ];
 
-    private string $type;
-
-    public function __construct(string $type)
+    public function __construct(private readonly string $type)
     {
-        /** @psalm-suppress RedundantCondition */
-        Assert::oneOf($type, array_keys(static::$defaultTime));
-
-        $this->type = $type;
+        Assert::oneOf($type, array_keys(self::$defaultTime));
     }
 
-    /** @param mixed|array $value */
-    public function transform(mixed $value): array
+    public function transform(mixed $value): mixed
     {
         return $value;
     }
 
-    /** @param mixed|array $value */
-    public function reverseTransform(mixed $value): array
+    public function reverseTransform(mixed $value): mixed
     {
-        if (!($value['date']['year'] ?? false)) {
+        if (!is_array($value)) {
             return $value;
         }
 
-        $value['time']['hour'] = $value['time']['hour'] === '' ? static::$defaultTime[$this->type]['hour'] : $value['time']['hour'];
-        $value['time']['minute'] = $value['time']['minute'] === '' ? static::$defaultTime[$this->type]['minute'] : $value['time']['minute'];
+        if (!isset($value['date']) || !is_array($value['date']) || !($value['date']['year'] ?? false)) {
+            return $value;
+        }
+
+        if (!isset($value['time']) || !is_array($value['time'])) {
+            return $value;
+        }
+
+        $value['time']['hour'] = $value['time']['hour'] === '' ? self::$defaultTime[$this->type]['hour'] : $value['time']['hour'];
+        $value['time']['minute'] = $value['time']['minute'] === '' ? self::$defaultTime[$this->type]['minute'] : $value['time']['minute'];
 
         return $value;
     }

--- a/src/Bundle/Maker/MakeGrid.php
+++ b/src/Bundle/Maker/MakeGrid.php
@@ -68,6 +68,7 @@ final class MakeGrid extends AbstractMaker
 
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
+        /** @var string $class */
         $class = $input->getArgument('entity');
 
         if (!\class_exists($class)) {
@@ -75,9 +76,11 @@ final class MakeGrid extends AbstractMaker
         }
 
         if (!\class_exists($class)) {
-            throw new RuntimeCommandException(\sprintf('Entity "%s" not found.', $input->getArgument('entity')));
+            $entityArg = $input->getArgument('entity');
+            throw new RuntimeCommandException(\sprintf('Entity "%s" not found.', is_string($entityArg) ? $entityArg : 'unknown'));
         }
 
+        /** @var string $namespace */
         $namespace = $input->getOption('namespace');
 
         // strip maker's root namespace if set
@@ -109,6 +112,9 @@ final class MakeGrid extends AbstractMaker
         // No dependencies needed
     }
 
+    /**
+     * @return string[]
+     */
     private function entityChoices(): array
     {
         $choices = [];
@@ -128,7 +134,11 @@ final class MakeGrid extends AbstractMaker
         return $choices;
     }
 
-    /** @param class-string $class */
+    /**
+     * @param class-string $class
+     *
+     * @return iterable<string, string|null>
+     */
     private function defaultFieldsFor(string $class): iterable
     {
         $entityManager = $this->managerRegistry?->getManagerForClass($class);

--- a/src/Bundle/Maker/MakeGrid.php
+++ b/src/Bundle/Maker/MakeGrid.php
@@ -77,6 +77,7 @@ final class MakeGrid extends AbstractMaker
 
         if (!\class_exists($class)) {
             $entityArg = $input->getArgument('entity');
+
             throw new RuntimeCommandException(\sprintf('Entity "%s" not found.', is_string($entityArg) ? $entityArg : 'unknown'));
         }
 

--- a/src/Bundle/Maker/MakeGrid.php
+++ b/src/Bundle/Maker/MakeGrid.php
@@ -68,7 +68,7 @@ final class MakeGrid extends AbstractMaker
 
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
-        /** @var string $class */
+        /** @var class-string $class */
         $class = $input->getArgument('entity');
 
         if (!\class_exists($class)) {
@@ -76,6 +76,7 @@ final class MakeGrid extends AbstractMaker
         }
 
         if (!\class_exists($class)) {
+            /** @var class-string $entityArg */
             $entityArg = $input->getArgument('entity');
 
             throw new RuntimeCommandException(\sprintf('Entity "%s" not found.', is_string($entityArg) ? $entityArg : 'unknown'));

--- a/src/Bundle/Registry/GridRegistry.php
+++ b/src/Bundle/Registry/GridRegistry.php
@@ -18,11 +18,10 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
 
 final class GridRegistry implements GridRegistryInterface
 {
-    private ServiceLocator $gridLocator;
-
-    public function __construct(ServiceLocator $gridLocator)
-    {
-        $this->gridLocator = $gridLocator;
+    public function __construct(
+        /** @var ServiceLocator<GridInterface> */
+        private ServiceLocator $gridLocator,
+    ) {
     }
 
     public function getGrid(string $code): ?GridInterface

--- a/src/Bundle/Renderer/TwigGridRenderer.php
+++ b/src/Bundle/Renderer/TwigGridRenderer.php
@@ -29,41 +29,18 @@ use Twig\Environment;
 
 final class TwigGridRenderer implements GridRendererInterface
 {
-    private Environment $twig;
-
-    private ServiceRegistryInterface $fieldsRegistry;
-
-    private FormFactoryInterface $formFactory;
-
-    private FormTypeRegistryInterface $formTypeRegistry;
-
-    private string $defaultTemplate;
-
-    private array $actionTemplates;
-
-    private array $filterTemplates;
-
-    private ?OptionsParserInterface $optionsParser;
-
     public function __construct(
-        Environment $twig,
-        ServiceRegistryInterface $fieldsRegistry,
-        FormFactoryInterface $formFactory,
-        FormTypeRegistryInterface $formTypeRegistry,
-        string $defaultTemplate,
-        array $actionTemplates = [],
-        array $filterTemplates = [],
-        ?OptionsParserInterface $optionsParser = null,
+        private Environment $twig,
+        private ServiceRegistryInterface $fieldsRegistry,
+        private FormFactoryInterface $formFactory,
+        private FormTypeRegistryInterface $formTypeRegistry,
+        private string $defaultTemplate,
+        /** @var array<string, string> $actionTemplates */
+        private array $actionTemplates = [],
+        /** @var array<string, string> $filterTemplates */
+        private array $filterTemplates = [],
+        private ?OptionsParserInterface $optionsParser = null,
     ) {
-        $this->twig = $twig;
-        $this->fieldsRegistry = $fieldsRegistry;
-        $this->formFactory = $formFactory;
-        $this->formTypeRegistry = $formTypeRegistry;
-        $this->defaultTemplate = $defaultTemplate;
-        $this->actionTemplates = $actionTemplates;
-        $this->filterTemplates = $filterTemplates;
-        $this->optionsParser = $optionsParser;
-
         if (null === $optionsParser) {
             trigger_deprecation(
                 'sylius/grid-bundle',
@@ -91,6 +68,8 @@ final class TwigGridRenderer implements GridRendererInterface
         if (null !== $this->optionsParser) {
             $options = $this->optionsParser->parseOptions($options);
         }
+
+        /** @var array<string, mixed> $options */
         $options = $resolver->resolve($options);
 
         return $fieldType->render($field, $data, $options);
@@ -127,6 +106,7 @@ final class TwigGridRenderer implements GridRendererInterface
             $filter->getFormOptions(),
         );
 
+        /** @var array<string, mixed> $criteria */
         $criteria = $gridView->getParameters()->get('criteria', []);
         $form->submit($criteria);
 

--- a/src/Bundle/Renderer/TwigGridRenderer.php
+++ b/src/Bundle/Renderer/TwigGridRenderer.php
@@ -30,16 +30,16 @@ use Twig\Environment;
 final class TwigGridRenderer implements GridRendererInterface
 {
     public function __construct(
-        private Environment $twig,
-        private ServiceRegistryInterface $fieldsRegistry,
-        private FormFactoryInterface $formFactory,
-        private FormTypeRegistryInterface $formTypeRegistry,
-        private string $defaultTemplate,
+        private readonly Environment $twig,
+        private readonly ServiceRegistryInterface $fieldsRegistry,
+        private readonly FormFactoryInterface $formFactory,
+        private readonly FormTypeRegistryInterface $formTypeRegistry,
+        private readonly string $defaultTemplate,
         /** @var array<string, string> $actionTemplates */
-        private array $actionTemplates = [],
+        private readonly array $actionTemplates = [],
         /** @var array<string, string> $filterTemplates */
-        private array $filterTemplates = [],
-        private ?OptionsParserInterface $optionsParser = null,
+        private readonly array $filterTemplates = [],
+        private readonly ?OptionsParserInterface $optionsParser = null,
     ) {
         if (null === $optionsParser) {
             trigger_deprecation(

--- a/src/Component/Definition/ArrayToDefinitionConverter.php
+++ b/src/Component/Definition/ArrayToDefinitionConverter.php
@@ -95,7 +95,9 @@ final class ArrayToDefinitionConverter implements ArrayToDefinitionConverterInte
             $field->setPosition($configuration['position']);
         }
         if (array_key_exists('options', $configuration)) {
-            $field->setOptions($configuration['options']);
+            /** @var array<string, mixed> $options */
+            $options = $configuration['options'];
+            $field->setOptions($options);
         }
 
         return $field;

--- a/src/Component/Definition/ArrayToDefinitionConverter.php
+++ b/src/Component/Definition/ArrayToDefinitionConverter.php
@@ -120,10 +120,14 @@ final class ArrayToDefinitionConverter implements ArrayToDefinitionConverterInte
             $filter->setPosition($configuration['position']);
         }
         if (array_key_exists('options', $configuration)) {
-            $filter->setOptions($configuration['options']);
+            /** @var array<string, mixed> $options */
+            $options = $configuration['options'];
+            $filter->setOptions($options);
         }
         if (array_key_exists('form_options', $configuration)) {
-            $filter->setFormOptions($configuration['form_options']);
+            /** @var array<string, mixed> $formOptions */
+            $formOptions = $configuration['form_options'];
+            $filter->setFormOptions($formOptions);
         }
         if (array_key_exists('default_value', $configuration)) {
             $filter->setCriteria($configuration['default_value']);

--- a/src/Component/Definition/ArrayToDefinitionConverter.php
+++ b/src/Component/Definition/ArrayToDefinitionConverter.php
@@ -41,7 +41,9 @@ final class ArrayToDefinitionConverter implements ArrayToDefinitionConverterInte
         $grid->setProvider($configuration['provider'] ?? null);
 
         if (array_key_exists('sorting', $configuration)) {
-            $grid->setSorting($configuration['sorting']);
+            /** @var array<string, string> $sorting */
+            $sorting = $configuration['sorting'];
+            $grid->setSorting($sorting);
         }
 
         if (array_key_exists('limits', $configuration)) {

--- a/src/Component/Definition/Field.php
+++ b/src/Component/Definition/Field.php
@@ -27,7 +27,7 @@ class Field
 
     private ?string $sortable = null;
 
-    /** @var array */
+    /** @var array<string, mixed> */
     private $options = [];
 
     /**
@@ -105,11 +105,17 @@ class Field
         return null !== $this->sortable;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getOptions(): array
     {
         return $this->options;
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function setOptions(array $options): void
     {
         $this->options = $options;

--- a/src/Component/Definition/Filter.php
+++ b/src/Component/Definition/Filter.php
@@ -152,8 +152,6 @@ class Filter
 
     /**
      * @param mixed $criteria
-     *
-     * @return void
      */
     public function setCriteria($criteria)
     {

--- a/src/Component/Definition/Filter.php
+++ b/src/Component/Definition/Filter.php
@@ -29,6 +29,7 @@ class Filter
     /** @var array<string, mixed> */
     private array $options = [];
 
+    /** @var array<string, mixed> */
     private array $formOptions = [];
 
     /** @var mixed */
@@ -107,16 +108,25 @@ class Filter
         return $this->options;
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function setOptions(array $options): void
     {
         $this->options = $options;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getFormOptions(): array
     {
         return $this->formOptions;
     }
 
+    /**
+     * @param array<string, mixed> $formOptions
+     */
     public function setFormOptions(array $formOptions): void
     {
         $this->formOptions = $formOptions;
@@ -143,7 +153,7 @@ class Filter
     /**
      * @param mixed $criteria
      *
-     * @psalm-suppress MissingReturnType
+     * @return void
      */
     public function setCriteria($criteria)
     {

--- a/src/Component/Definition/Grid.php
+++ b/src/Component/Definition/Grid.php
@@ -27,7 +27,7 @@ class Grid
     /** @var string|callable|null */
     private $provider;
 
-    /** @var array */
+    /** @var array<string, string> */
     private $sorting = [];
 
     /** @var array */
@@ -96,11 +96,17 @@ class Grid
         $this->provider = $provider;
     }
 
+    /**
+     * @return array<string, string>
+     */
     public function getSorting(): array
     {
         return $this->sorting;
     }
 
+    /**
+     * @param array<string, string> $sorting
+     */
     public function setSorting(array $sorting): void
     {
         $this->sorting = $sorting;

--- a/src/Component/Definition/Grid.php
+++ b/src/Component/Definition/Grid.php
@@ -33,7 +33,7 @@ class Grid
     /** @var array */
     private $limits = [];
 
-    /** @var array */
+    /** @var array<string, Field> */
     private $fields = [];
 
     /** @var array<string, Filter> */
@@ -117,7 +117,7 @@ class Grid
     }
 
     /**
-     * @return array|Field[]
+     * @return array<string, Field>
      */
     public function getFields(): array
     {
@@ -125,7 +125,7 @@ class Grid
     }
 
     /**
-     * @return array|Field[]
+     * @return array<string, Field>
      */
     public function getEnabledFields(): array
     {

--- a/src/Component/Definition/Grid.php
+++ b/src/Component/Definition/Grid.php
@@ -36,7 +36,7 @@ class Grid
     /** @var array */
     private $fields = [];
 
-    /** @var array */
+    /** @var array<string, Filter> */
     private $filters = [];
 
     /** @var array */
@@ -253,7 +253,7 @@ class Grid
     }
 
     /**
-     * @return array|Filter[]
+     * @return array<string, Filter>
      */
     public function getFilters(): array
     {
@@ -261,7 +261,7 @@ class Grid
     }
 
     /**
-     * @return array|Filter[]
+     * @return array<string, Filter>
      */
     public function getEnabledFilters(): array
     {

--- a/src/Component/Filter/DateFilter.php
+++ b/src/Component/Filter/DateFilter.php
@@ -24,6 +24,19 @@ final class DateFilter implements FilterInterface
 
     public const DEFAULT_INCLUSIVE_TO = false;
 
+    /**
+     * @param array{
+     *     from?: array{
+     *        date: string,
+     *        time?: string,
+     *     },
+     *     to?: array{
+     *        date: string,
+     *        time?: string,
+     *     },
+     * } $data
+     * @param array<string, mixed> $options
+     */
     public function apply(DataSourceInterface $dataSource, string $name, $data, array $options): void
     {
         $expressionBuilder = $dataSource->getExpressionBuilder();
@@ -52,6 +65,7 @@ final class DateFilter implements FilterInterface
     }
 
     /**
+     * @param array<string, mixed> $options
      * @param mixed $default
      *
      * @return mixed
@@ -62,7 +76,10 @@ final class DateFilter implements FilterInterface
     }
 
     /**
-     * @param string[] $data
+     * @param array{
+     *     date: string,
+     *     time?: string,
+     * } $data
      */
     private function getDateTime(array $data, string $defaultTime): ?string
     {

--- a/src/Component/Filter/NumericRangeFilter.php
+++ b/src/Component/Filter/NumericRangeFilter.php
@@ -26,6 +26,12 @@ final class NumericRangeFilter implements FilterInterface
 
     public const DEFAULT_INCLUSIVE_TO = true;
 
+    /**
+     * @param array{
+     *     greaterThan?: string,
+     *     lessThan?: string,
+     * } $data
+     */
     public function apply(DataSourceInterface $dataSource, string $name, $data, array $options): void
     {
         if (empty($data)) {
@@ -69,7 +75,12 @@ final class NumericRangeFilter implements FilterInterface
         return (int) round($amount * (10 ** $scale), $mode);
     }
 
-    /** @param array<array-key, string> $data */
+    /**
+     * @param array{
+     *     greaterThan?: string,
+     *     lessThan?: string,
+     * } $data
+     */
     private function getDataValue(array $data, string $key): string
     {
         return $data[$key] ?? '';

--- a/src/Component/Filter/StringFilter.php
+++ b/src/Component/Filter/StringFilter.php
@@ -44,12 +44,20 @@ final class StringFilter implements FilterInterface
 
     public const TYPE_NOT_IN = 'not_in';
 
+    /**
+     * @param array{
+     *     type?: string,
+     *     value?: string,
+     * }|string|null $data
+     */
     public function apply(DataSourceInterface $dataSource, string $name, $data, array $options): void
     {
         $expressionBuilder = $dataSource->getExpressionBuilder();
 
         $value = is_array($data) ? $data['value'] ?? null : $data;
+        /** @var string $type */
         $type = $data['type'] ?? ($options['type'] ?? self::TYPE_CONTAINS);
+        /** @var string[] $fields */
         $fields = $options['fields'] ?? [$name];
 
         if (!in_array($type, [self::TYPE_NOT_EMPTY, self::TYPE_EMPTY], true) && '' === trim((string) $value)) {
@@ -77,7 +85,7 @@ final class StringFilter implements FilterInterface
     }
 
     /**
-     * @param mixed $value
+     * @param string|null $value
      *
      * @return mixed
      *
@@ -107,9 +115,9 @@ final class StringFilter implements FilterInterface
             case self::TYPE_ENDS_WITH:
                 return $expressionBuilder->like($field, '%' . $value);
             case self::TYPE_IN:
-                return $expressionBuilder->in($field, array_map('trim', explode(',', $value)));
+                return $expressionBuilder->in($field, array_map('trim', explode(',', (string) $value)));
             case self::TYPE_NOT_IN:
-                return $expressionBuilder->notIn($field, array_map('trim', explode(',', $value)));
+                return $expressionBuilder->notIn($field, array_map('trim', explode(',', (string) $value)));
             case self::TYPE_MEMBER_OF:
                 if (method_exists($expressionBuilder, 'memberOf')) {
                     return $expressionBuilder->memberOf($value, $field);

--- a/src/Component/Filtering/FiltersCriteriaResolver.php
+++ b/src/Component/Filtering/FiltersCriteriaResolver.php
@@ -27,14 +27,16 @@ final class FiltersCriteriaResolver implements FiltersCriteriaResolverInterface
     public function getCriteria(Grid $grid, Parameters $parameters): array
     {
         $defaultCriteria = array_map(
-            /** @return mixed */
             function (Filter $filter) {
                 return $filter->getCriteria();
             },
             $this->getFiltersDefaultCriteria($grid->getFilters()),
         );
 
-        return $parameters->get('criteria', $defaultCriteria);
+        /** @var array<string, mixed> $criteria */
+        $criteria = $parameters->get('criteria', $defaultCriteria);
+
+        return $criteria;
     }
 
     /**

--- a/src/Component/Filtering/FiltersCriteriaResolverInterface.php
+++ b/src/Component/Filtering/FiltersCriteriaResolverInterface.php
@@ -20,5 +20,8 @@ interface FiltersCriteriaResolverInterface
 {
     public function hasCriteria(Grid $grid, Parameters $parameters): bool;
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getCriteria(Grid $grid, Parameters $parameters): array;
 }

--- a/src/Component/Sorting/Sorter.php
+++ b/src/Component/Sorting/Sorter.php
@@ -39,6 +39,7 @@ final class Sorter implements SorterInterface
 
         $expressionBuilder = $dataSource->getExpressionBuilder();
 
+        /** @var array<string, string> $sorting */
         $sorting = $parameters->get('sorting', $grid->getSorting());
         $this->sortingValidator->validateSortingParameters($sorting, $enabledFields);
 

--- a/src/Component/View/GridView.php
+++ b/src/Component/View/GridView.php
@@ -71,7 +71,10 @@ class GridView implements GridViewInterface
         $this->assertFieldIsSortable($fieldName);
 
         if ($this->parameters->has('sorting')) {
-            return array_key_exists($fieldName, $this->parameters->get('sorting'));
+            /** @var array<string, string> $sorting */
+            $sorting = $this->parameters->get('sorting');
+
+            return array_key_exists($fieldName, $sorting);
         }
 
         $sortingDefinition = $this->getDefinition()->getSorting();
@@ -80,12 +83,20 @@ class GridView implements GridViewInterface
         return $fieldName === array_shift($sortedFields);
     }
 
+    /**
+     * @return array<string, string>
+     */
     private function getCurrentlySortedBy(): array
     {
-        return $this->parameters->has('sorting')
-            ? array_merge($this->definition->getSorting(), $this->parameters->get('sorting'))
-            : $this->definition->getSorting()
-        ;
+        $defaultSorting = $this->definition->getSorting();
+        if (!$this->parameters->has('sorting')) {
+            return $defaultSorting;
+        }
+
+        /** @var array<string, string> $sorting */
+        $sorting = $this->parameters->get('sorting');
+
+        return array_merge($defaultSorting, $sorting);
     }
 
     /**


### PR DESCRIPTION
In this PR, I removed all excluded files and fixed the related issues for them (excluding a deprecated class):

        - src/Bundle/Config/GridConfigInterface.php
        - src/Bundle/Doctrine/ORM/ExpressionBuilder.php
        - src/Bundle/DependencyInjection/Configuration.php
        - src/Bundle/Form/DataTransformer/DateTimeFilterTransformer.php
        - src/Bundle/Maker/MakeGrid.php
        - src/Bundle/Registry/GridRegistry.php
        - src/Bundle/Renderer/TwigGridRenderer.php
        - src/Component/DataExtractor/PropertyAccessDataExtractor.php
        - src/Component/Definition/Filter.php
        - src/Component/Filter/DateFilter.php
        - src/Component/Filter/NumericRangeFilter.php
        - src/Component/Filter/StringFilter.php
        - src/Component/Filtering/FiltersCriteriaResolver.php
        - src/Component/Sorting/Sorter.php
        - src/Component/View/GridView.php

Finally I removed from the baseline the ignored errors related to the changes made. 