### PR TITLE
Fix sf7.4 ci

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -14,7 +14,6 @@ parameters:
         - src/Bundle/Config/GridConfigInterface.php
         - src/Bundle/Doctrine/PHPCRODM/*
         - src/Bundle/Doctrine/ORM/ExpressionBuilder.php
-        - src/Bundle/DependencyInjection/Configuration.php
         - src/Bundle/Form/DataTransformer/DateTimeFilterTransformer.php
         - src/Bundle/Maker/MakeGrid.php
         - src/Bundle/Registry/GridRegistry.php
@@ -40,3 +39,12 @@ parameters:
         - '/Cannot cast mixed to string./'
         - '/Class Sylius\\Bundle\\CurrencyBundle\\Form\\Type\\CurrencyChoiceType not found\./'
         - '/Unable to resolve the template type T in call to method Doctrine\\Persistence\\ObjectManager::getRepository\(\)/'
+        # Symfony 7.4
+        - message: '#^Call to method .+\.$#'
+          identifier: class.notFound
+          count: 3
+          path: src/Bundle/DependencyInjection/Configuration.php
+        - message: '#^Cannot call method [^\(]+\(\) on mixed\.$#'
+          identifier: method.nonObject
+          count: 166
+          path: src/Bundle/DependencyInjection/Configuration.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -39,7 +39,12 @@ parameters:
         - '/Cannot cast mixed to string./'
         - '/Class Sylius\\Bundle\\CurrencyBundle\\Form\\Type\\CurrencyChoiceType not found\./'
         - '/Unable to resolve the template type T in call to method Doctrine\\Persistence\\ObjectManager::getRepository\(\)/'
-        # Symfony 7.4
+        # Symfony <7.4
+        - message: '#^PHPDoc tag .+ is not generic\.$#'
+          identifier: generics.notGeneric
+          count: 9
+          path: src/Bundle/DependencyInjection/Configuration.php
+        # Symfony >=7.4
         - message: '#^Call to method .+\.$#'
           identifier: class.notFound
           count: 3

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/7.0/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          colors="true"
 >
     <php>

--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -21,11 +21,14 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 final class Configuration implements ConfigurationInterface
 {
+    /**
+     * @return TreeBuilder<'array'>
+     */
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sylius_grid');
 
-        /** @var ArrayNodeDefinition $rootNode */
+        /** @var ArrayNodeDefinition<TreeBuilder<'array'>> $rootNode */
         $rootNode = $treeBuilder->getRootNode();
 
         $this->addDriversSection($rootNode);
@@ -35,6 +38,9 @@ final class Configuration implements ConfigurationInterface
         return $treeBuilder;
     }
 
+    /**
+     * @param ArrayNodeDefinition<TreeBuilder<'array'>> $node
+     */
     private function addDriversSection(ArrayNodeDefinition $node): void
     {
         $node
@@ -48,6 +54,9 @@ final class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * @param ArrayNodeDefinition<TreeBuilder<'array'>> $node
+     */
     private function addTemplatesSection(ArrayNodeDefinition $node): void
     {
         $node
@@ -73,6 +82,9 @@ final class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * @param ArrayNodeDefinition<TreeBuilder<'array'>> $node
+     */
     private function addGridsSection(ArrayNodeDefinition $node): void
     {
         $node


### PR DESCRIPTION
Symfony 7.4 introduced templates on some interfaces and objects used to create bundle configuration.
In order to fix the CI when using Symfony 7.4 this PR aimed to fix or ignore errors generated by the Symfony upgrade.