### PR TITLE
 [Bug] fix: use withFields and withFilters instead of addFields and addFilters in make:grid skeleton

### DIFF
--- a/src/Bundle/Resources/config/skeleton/Grid.tpl.php
+++ b/src/Bundle/Resources/config/skeleton/Grid.tpl.php
@@ -37,9 +37,9 @@ final class <?= $class_name ?> extends AbstractGrid
     {
         $gridBuilder
             // see https://stack.sylius.com/grid/index/filters
-            // ->addFilters()
+            // ->withFilters()
             // see https://stack.sylius.com/grid/index/field_types
-            ->addFields(
+            ->withFields(
 <?php
                 foreach ($defaultFields as $fieldname => $type) {
                     if (in_array($type, ['STRING', 'TEXT'], true)) {

--- a/src/Bundle/Tests/Functional/Maker/MakeGridTest.php
+++ b/src/Bundle/Tests/Functional/Maker/MakeGridTest.php
@@ -181,9 +181,9 @@ final class BookGrid extends AbstractGrid
     {
         $gridBuilder
             // see https://stack.sylius.com/grid/index/filters
-            // ->addFilters()
+            // ->withFilters()
             // see https://stack.sylius.com/grid/index/field_types
-            ->addFields(
+            ->withFields(
                 StringField::create('title')
                     ->setLabel('Title')
                     ->setSortable(true),
@@ -262,9 +262,9 @@ final class PriceGrid extends AbstractGrid
     {
         \$gridBuilder
             // see https://stack.sylius.com/grid/index/filters
-            // ->addFilters()
+            // ->withFilters()
             // see https://stack.sylius.com/grid/index/field_types
-            ->addFields(
+            ->withFields(
                 StringField::create('currencyCode')
                     ->setLabel('CurrencyCode')
                     ->setSortable(true),
@@ -329,9 +329,9 @@ final class AdminUserGrid extends AbstractGrid
     {
         \$gridBuilder
             // see https://stack.sylius.com/grid/index/filters
-            // ->addFilters()
+            // ->withFilters()
             // see https://stack.sylius.com/grid/index/field_types
-            ->addFields(
+            ->withFields(
                 StringField::create('username')
                     ->setLabel('Username')
                     ->setSortable(true),
@@ -399,9 +399,9 @@ final class BoardGameGrid extends AbstractGrid
     {
         \$gridBuilder
             // see https://stack.sylius.com/grid/index/filters
-            // ->addFilters()
+            // ->withFilters()
             // see https://stack.sylius.com/grid/index/field_types
-            ->addFields(
+            ->withFields(
                 StringField::create('name')
                     ->setLabel('Name')
                     ->setSortable(true),


### PR DESCRIPTION
 Fixes #476

  ## Changes

 Replace `addFields` and `addFilters` with `withFields` and `withFilters` in the `make:grid` skeleton template, as `addFields` and `addFilters` methods do not exist on`GridBuilder`.ake:grid skeleton