### PR TITLE
feat(DX): Invokable grids

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,48 @@
+## UPGRADE FOR `1.16.x`
+
+### FROM `1.15.x` TO `1.16.x`
+
+#### PHP Grids
+
+The `Sylius\Bundle\GridBundle\Grid\AbstractGrid` and the `Sylius\Bundle\GridBundle\Grid\GridInterface` are deprecated.
+You should use the `Sylius\Component\Grid\Attribute\AsGrid` attribute only.
+
+```diff
+<?php
+
+declare(strict_types=1);
+
+namespace App\Grid;
+
+use App\Entity\Book;
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
+use Sylius\Bundle\GridBundle\Grid\AbstractGrid;
+use Sylius\Bundle\GridBundle\Grid\ResourceAwareGridInterface;
+use Sylius\Component\Grid\Attribute\AsGrid;
+
++#[AsGrid(resourceClass: Book::class, name: 'app_book')]
+-final class BookGrid extends AbstractGrid implements ResourceAwareGridInterface
++final class BookGrid
+{
+-    public function buildGrid(GridBuilderInterface $gridBuilder): void
++    public function __invoke(GridBuilderInterface $gridBuilder): void
+    {
+        // ...
+    }
+-    
+-    public function getResourceClass(): string
+-    {
+-        return Book::class;
+-    }
+-
+-    public static function getName(): string
+-    {
+-        return 'app_book'
+-    }
+}
+
+```
+
 ## UPGRADE FOR `1.15.x`
 
 ### FROM `1.14.x` TO `1.15.x`

--- a/composer.json
+++ b/composer.json
@@ -62,11 +62,11 @@
     },
     "require-dev": {
         "babdev/pagerfanta-bundle": "^4.4",
-        "doctrine/doctrine-bundle": "^2.0 || ^3.0 || ^4.0",
         "doctrine/dbal": "^2.11 || ^3.0 || ^4.0",
+        "doctrine/doctrine-bundle": "^2.0 || ^3.0 || ^4.0",
         "doctrine/orm": "^2.8 || ^3.0",
-        "doctrine/phpcr-odm": "^1.5 || ^2.0",
         "doctrine/persistence": "^1.3 || ^2.0 || ^3.1 || ^4.0",
+        "doctrine/phpcr-odm": "^1.5 || ^2.0",
         "jackalope/jackalope-doctrine-dbal": "^2.0",
         "matthiasnoback/symfony-config-test": "^6.1",
         "matthiasnoback/symfony-dependency-injection-test": "^6.1",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -36,7 +36,7 @@ parameters:
         # Symfony Dependency Injection Reflector
         - message: '#^Parameter \#2 \$configurator of method Symfony\\Component\\DependencyInjection\\ContainerBuilder\:\:registerAttributeForAutoconfiguration\(\)#'
           identifier: argument.type
-          count: 2
+          count: 4
           path: src/Bundle/DependencyInjection/SyliusGridExtension.php
         # Symfony 8 without Doctrine PHPCR-ODM
         - message: '#^Method Sylius\\Bundle\\GridBundle\\Doctrine\\DataSourceInterface\:\:getQueryBuilder\(\) has invalid return type Doctrine\\ODM\\PHPCR\\Query\\Builder\\QueryBuilder\.$#'

--- a/src/Bundle/Command/DebugGridCommand.php
+++ b/src/Bundle/Command/DebugGridCommand.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\GridBundle\Command;
 
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
+use Sylius\Bundle\GridBundle\Grid\GridInterface as LegacyGridInterface;
+use Sylius\Bundle\GridBundle\Grid\InvokableGrid;
+use Sylius\Component\Grid\GridInterface;
 use Sylius\Component\Grid\Provider\GridProviderInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -121,8 +123,27 @@ EOF
      */
     private function getGridChoices(): array
     {
+        $taggedGrids = [];
+
+        foreach ($this->taggedGrids->getProvidedServices() as $id => $class) {
+            $grid = $this->taggedGrids->get($id);
+
+            if ($grid instanceof LegacyGridInterface) {
+                $taggedGrids[] = $grid::getName();
+            }
+
+            if ($grid instanceof GridInterface) {
+                $taggedGrids[] = $grid->getName();
+            }
+
+            if ($grid instanceof InvokableGrid and null !== $grid->getClass()) {
+                // It allows to reference the grid by its FQCN
+                $taggedGrids[] = $grid->getClass();
+            }
+        }
+
         $grids = array_merge(
-            $this->taggedGrids->getProvidedServices(),
+            $taggedGrids,
             array_keys($this->gridConfigurations),
         );
 

--- a/src/Bundle/DependencyInjection/Compiler/AttributeGridPass.php
+++ b/src/Bundle/DependencyInjection/Compiler/AttributeGridPass.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\GridBundle\DependencyInjection\Compiler;
+
+use Sylius\Bundle\GridBundle\Grid\GridInterface;
+use Sylius\Bundle\GridBundle\Grid\InvokableGrid;
+use Sylius\Component\Grid\Attribute\AsGrid;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Register an instance of AttributeGrid for each service using the
+ * PHP attributes to declare Grids.
+ *
+ * @internal
+ */
+final class AttributeGridPass implements CompilerPassInterface
+{
+    private const TAG = 'sylius.attribute_grid';
+
+    /**
+     * @param \ReflectionClass<AsGrid> $reflector
+     */
+    public static function autoconfigureFromAttribute(ChildDefinition $definition, AsGrid $attribute, \ReflectionClass $reflector): void
+    {
+        $class = $reflector->name;
+        if (is_a($class, GridInterface::class, true)) {
+            return;
+        }
+
+        $definition->addTag(self::TAG, [
+            'class' => $class,
+            'name' => $attribute->name ?? $class,
+            'resourceClass' => $attribute->resourceClass,
+            'buildMethod' => $attribute->buildMethod,
+            'provider' => $attribute->provider,
+        ]);
+    }
+
+    public function process(ContainerBuilder $container): void
+    {
+        foreach ($container->findTaggedServiceIds(self::TAG, true) as $id => $tags) {
+            /** @var array<string, string|null> $attribute */
+            foreach ($tags as $attribute) {
+                /** @var string $class */
+                $class = $attribute['class'] ?? throw new LogicException(sprintf('"class" attribute not found on "sylius.grid" tag for "%s" service.', $id));
+
+                /** @var string $name */
+                $name = $attribute['name'] ?? $class;
+
+                /** @var string|null $resourceClass */
+                $resourceClass = $attribute['resourceClass'] ?? null;
+
+                /** @var string|null $buildMethod */
+                $buildMethod = $attribute['buildMethod'] ?? null;
+
+                /** @var string|null $provider */
+                $provider = $attribute['provider'] ?? null;
+
+                $container->register('.sylius.grid.' . $id, InvokableGrid::class)
+                    ->setArguments([new Reference($id), $name, $class, $resourceClass, $buildMethod, $provider])
+                    ->addTag('sylius.grid', ['name' => $name])
+                    ->addTag('sylius.grid', ['name' => $class])
+                ;
+            }
+        }
+    }
+}

--- a/src/Bundle/DependencyInjection/SyliusGridExtension.php
+++ b/src/Bundle/DependencyInjection/SyliusGridExtension.php
@@ -16,11 +16,14 @@ namespace Sylius\Bundle\GridBundle\DependencyInjection;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Doctrine\Bundle\PHPCRBundle\DoctrinePHPCRBundle;
 use Sylius\Bundle\CurrencyBundle\SyliusCurrencyBundle;
+use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\AttributeGridPass;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
+use Sylius\Bundle\GridBundle\Grid\InvokableGrid;
 use Sylius\Bundle\GridBundle\SyliusGridBundle;
 use Sylius\Component\Grid\Annotation\AsGridFieldCallableService;
 use Sylius\Component\Grid\Attribute\AsField;
 use Sylius\Component\Grid\Attribute\AsFilter;
+use Sylius\Component\Grid\Attribute\AsGrid;
 use Sylius\Component\Grid\Data\DataProviderInterface;
 use Sylius\Component\Grid\Filtering\ConfigurableFilterInterface;
 use Symfony\Component\Config\FileLocator;
@@ -93,6 +96,21 @@ final class SyliusGridExtension extends Extension
                 ]);
             },
         );
+
+        $container->registerAttributeForAutoconfiguration(AsGrid::class, static function (ChildDefinition $definition, AsGrid $attribute, \ReflectionClass $reflector) use ($container): void {
+            if (is_a($reflector->name, GridInterface::class, true)) {
+                return;
+            }
+
+            $container->register('sylius.grid', InvokableGrid::class)
+                ->setArguments([
+                    $attribute->name,
+                ])
+                ->addTag('sylius.grid')
+            ;
+        });
+
+        $container->registerAttributeForAutoconfiguration(AsGrid::class, AttributeGridPass::autoconfigureFromAttribute(...));
 
         $container->registerAttributeForAutoconfiguration(
             AsField::class,

--- a/src/Bundle/Grid/AbstractGrid.php
+++ b/src/Bundle/Grid/AbstractGrid.php
@@ -18,6 +18,9 @@ use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Component\Grid\Attribute\AsGrid;
 use Sylius\Component\Grid\Exception\LogicException;
 
+/**
+ * @deprecated since Sylius Grid 1.16, will be removed in 2.0, use the Sylius\Component\Grid\Attribute\AsGrid attribute only.
+ */
 abstract class AbstractGrid implements GridInterface
 {
     public static function getName(): string

--- a/src/Bundle/Grid/GridInterface.php
+++ b/src/Bundle/Grid/GridInterface.php
@@ -15,6 +15,9 @@ namespace Sylius\Bundle\GridBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 
+/**
+ * @deprecated since Sylius Grid 1.16, will be removed in 2.0, use Sylius\Component\Grid\GridInterface instead
+ */
 interface GridInterface
 {
     public static function getName(): string;

--- a/src/Bundle/Grid/InvokableGrid.php
+++ b/src/Bundle/Grid/InvokableGrid.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\GridBundle\Grid;
+
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
+use Sylius\Component\Grid\Exception\LogicException;
+use Sylius\Component\Grid\GridInterface;
+
+/**
+ * @internal
+ */
+final class InvokableGrid implements GridInterface
+{
+    /** @var callable */
+    private $code;
+
+    public function __construct(
+        object|callable $code,
+        private readonly string $name,
+        private readonly ?string $class = null,
+        private readonly ?string $resourceClass = null,
+        public readonly ?string $buildMethod = null,
+        private readonly ?string $provider = null,
+    ) {
+        if (!is_callable($code)) {
+            $code = [$code, $this->buildMethod];
+        }
+
+        if (!is_callable($code)) {
+            throw new LogicException('Your grid should be a callable.');
+        }
+
+        $this->code = $code;
+    }
+
+    public function __invoke(GridBuilderInterface $builder): void
+    {
+        ($this->code)($builder);
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getClass(): ?string
+    {
+        return $this->class;
+    }
+
+    public function getResourceClass(): ?string
+    {
+        return $this->resourceClass;
+    }
+
+    public function getProvider(): ?string
+    {
+        return $this->provider;
+    }
+}

--- a/src/Bundle/Grid/ResourceAwareGridInterface.php
+++ b/src/Bundle/Grid/ResourceAwareGridInterface.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\GridBundle\Grid;
 
+/**
+ * @deprecated since Sylius Grid 1.16, will be removed in 2.0, use the Sylius\Component\Grid\Attribute\AsGrid attribute only.
+ */
 interface ResourceAwareGridInterface extends GridInterface
 {
     public function getResourceClass(): string;

--- a/src/Bundle/Provider/ServiceGridProvider.php
+++ b/src/Bundle/Provider/ServiceGridProvider.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\GridBundle\Provider;
 
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
+use Sylius\Bundle\GridBundle\Builder\GridBuilder;
+use Sylius\Bundle\GridBundle\Grid\GridInterface as LegacyGridInterface;
+use Sylius\Bundle\GridBundle\Grid\InvokableGrid;
 use Sylius\Bundle\GridBundle\Registry\GridRegistryInterface;
 use Sylius\Component\Grid\Configuration\GridConfigurationExtenderInterface;
 use Sylius\Component\Grid\Configuration\GridConfigurationRemovalsHandler;
@@ -22,7 +24,9 @@ use Sylius\Component\Grid\Configuration\GridConfigurationSortingHandler;
 use Sylius\Component\Grid\Configuration\GridConfigurationSortingHandlerInterface;
 use Sylius\Component\Grid\Definition\ArrayToDefinitionConverterInterface;
 use Sylius\Component\Grid\Definition\Grid;
+use Sylius\Component\Grid\Exception\LogicException;
 use Sylius\Component\Grid\Exception\UndefinedGridException;
+use Sylius\Component\Grid\GridInterface;
 use Sylius\Component\Grid\Provider\GridProviderInterface;
 use Webmozart\Assert\Assert;
 
@@ -54,7 +58,7 @@ final class ServiceGridProvider implements GridProviderInterface
 
     public function get(string $code): Grid
     {
-        if (is_a($code, GridInterface::class, true)) {
+        if (is_a($code, LegacyGridInterface::class, true)) {
             $code = $code::getName();
         }
 
@@ -64,7 +68,7 @@ final class ServiceGridProvider implements GridProviderInterface
             throw new UndefinedGridException($code);
         }
 
-        $gridConfiguration = $grid->toArray();
+        $gridConfiguration = $this->getGridConfiguration($grid);
 
         if (isset($gridConfiguration['extends'])) {
             /** @var string $parentGridCode */
@@ -89,8 +93,32 @@ final class ServiceGridProvider implements GridProviderInterface
 
         Assert::notNull($parentGrid, sprintf('Parent grid with code "%s" does not exists.', $parentGridCode));
 
-        $parentGridConfiguration = $parentGrid->toArray();
+        $parentGridConfiguration = $this->getGridConfiguration($parentGrid);
 
         return $this->gridConfigurationExtender->extends($gridConfiguration, $parentGridConfiguration);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getGridConfiguration(LegacyGridInterface|GridInterface $grid): array
+    {
+        if ($grid instanceof LegacyGridInterface) {
+            return $grid->toArray();
+        }
+
+        if (!$grid instanceof InvokableGrid) {
+            throw new LogicException(sprintf('"%s" should be an instance of "%s"', $grid::class, InvokableGrid::class));
+        }
+
+        $gridBuilder = GridBuilder::create($grid->getName(), $grid->getResourceClass());
+
+        if (null !== $grid->getProvider()) {
+            $gridBuilder->setProvider($grid->getProvider());
+        }
+
+        $grid($gridBuilder);
+
+        return $gridBuilder->toArray();
     }
 }

--- a/src/Bundle/Registry/GridRegistry.php
+++ b/src/Bundle/Registry/GridRegistry.php
@@ -13,7 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\GridBundle\Registry;
 
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
+use Sylius\Bundle\GridBundle\Grid\GridInterface as LegacyGridInterface;
+use Sylius\Component\Grid\GridInterface;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 
 final class GridRegistry implements GridRegistryInterface
@@ -24,7 +25,7 @@ final class GridRegistry implements GridRegistryInterface
     ) {
     }
 
-    public function getGrid(string $code): ?GridInterface
+    public function getGrid(string $code): LegacyGridInterface|GridInterface|null
     {
         return $this->gridLocator->has($code) ? $this->gridLocator->get($code) : null;
     }

--- a/src/Bundle/Registry/GridRegistryInterface.php
+++ b/src/Bundle/Registry/GridRegistryInterface.php
@@ -13,9 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\GridBundle\Registry;
 
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
+use Sylius\Bundle\GridBundle\Grid\GridInterface as LegacyGridInterface;
+use Sylius\Component\Grid\GridInterface;
 
 interface GridRegistryInterface
 {
-    public function getGrid(string $code): ?GridInterface;
+    public function getGrid(string $code): LegacyGridInterface|GridInterface|null;
 }

--- a/src/Bundle/SyliusGridBundle.php
+++ b/src/Bundle/SyliusGridBundle.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\GridBundle;
 
+use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\AttributeGridPass;
 use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\RegisterDriversPass;
 use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\RegisterFieldTypesPass;
 use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\RegisterFiltersPass;
@@ -38,6 +39,7 @@ final class SyliusGridBundle extends Bundle
         $container->addCompilerPass(new RegisterStubCommandsPass());
         $container->addCompilerPass(new RegisterTimezoneParameterPass());
         $container->addCompilerPass(new ValidateConfiguredGridDriversPass());
+        $container->addCompilerPass(new AttributeGridPass());
     }
 
     /**

--- a/src/Bundle/Tests/DependencyInjection/Compiler/AttributeGridPassTest.php
+++ b/src/Bundle/Tests/DependencyInjection/Compiler/AttributeGridPassTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\GridBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\AttributeGridPass;
+use Sylius\Bundle\GridBundle\Grid\InvokableGrid;
+use Sylius\Component\Grid\Attribute\AsGrid;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class AttributeGridPassTest extends TestCase
+{
+    public function test_it_adds_attribute_grid_tag_when_autoconfiguring(): void
+    {
+        $definition = new ChildDefinition('base');
+
+        $attribute = new AsGrid(
+            resourceClass: 'App\Entity\Product',
+            name: 'admin_product',
+            buildMethod: 'buildGrid',
+            provider: 'app.provider',
+        );
+
+        $reflector = new \ReflectionClass(DummyGrid::class);
+
+        AttributeGridPass::autoconfigureFromAttribute(
+            $definition,
+            $attribute,
+            $reflector,
+        );
+
+        $this->assertSame([
+            [
+                'class' => DummyGrid::class,
+                'name' => 'admin_product',
+                'resourceClass' => 'App\Entity\Product',
+                'buildMethod' => 'buildGrid',
+                'provider' => 'app.provider',
+            ],
+        ], $definition->getTag('sylius.attribute_grid'));
+    }
+
+    public function test_it_registers_invokable_grid_services(): void
+    {
+        $container = new ContainerBuilder();
+
+        $container
+            ->register('app.grid')
+            ->addTag('sylius.attribute_grid', [
+                'class' => DummyGrid::class,
+                'name' => 'admin_product',
+                'resourceClass' => 'App\Entity\Product',
+                'buildMethod' => 'buildGrid',
+                'provider' => 'app.provider',
+            ]);
+
+        $pass = new AttributeGridPass();
+
+        $pass->process($container);
+
+        $definition = $container->getDefinition('.sylius.grid.app.grid');
+
+        $this->assertSame(
+            InvokableGrid::class,
+            $definition->getClass(),
+        );
+
+        $this->assertEquals([
+            new Reference('app.grid'),
+            'admin_product',
+            DummyGrid::class,
+            'App\Entity\Product',
+            'buildGrid',
+            'app.provider',
+        ], $definition->getArguments());
+
+        $this->assertSame([
+            ['name' => 'admin_product'],
+            ['name' => DummyGrid::class],
+        ], $definition->getTag('sylius.grid'));
+    }
+
+    public function test_it_throws_when_class_attribute_is_missing(): void
+    {
+        $container = new ContainerBuilder();
+
+        $container
+            ->register('app.grid')
+            ->addTag('sylius.attribute_grid', []);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('"class" attribute not found on "sylius.grid" tag for "app.grid" service.');
+
+        (new AttributeGridPass())->process($container);
+    }
+}
+
+final class DummyGrid
+{
+}

--- a/src/Bundle/Tests/Functional/Command/DebugGridCommandTest.php
+++ b/src/Bundle/Tests/Functional/Command/DebugGridCommandTest.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Functional\Command;
+namespace Sylius\Bundle\GridBundle\Tests\Functional\Command;
 
 use App\BoardGameBlog\Infrastructure\Sylius\Grid\BoardGameGrid;
 use Symfony\Bundle\FrameworkBundle\Console\Application;

--- a/src/Bundle/Tests/Integration/Provider/ServiceGridProviderTest.php
+++ b/src/Bundle/Tests/Integration/Provider/ServiceGridProviderTest.php
@@ -13,13 +13,15 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\GridBundle\Tests\Integration\Provider;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Sylius\Bundle\GridBundle\Provider\ServiceGridProvider;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
+#[CoversClass(ServiceGridProvider::class)]
 final class ServiceGridProviderTest extends KernelTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function test_grids_inheritance(): void
     {
         self::bootKernel(['environment' => 'test_grids_as_service']);

--- a/src/Bundle/Tests/Unit/Provider/ServiceGridProviderTest.php
+++ b/src/Bundle/Tests/Unit/Provider/ServiceGridProviderTest.php
@@ -15,7 +15,9 @@ namespace Sylius\Bundle\GridBundle\Tests\Unit\Provider;
 
 use App\Grid\BookGrid;
 use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
+use Sylius\Bundle\GridBundle\Grid\InvokableGrid;
 use Sylius\Bundle\GridBundle\Provider\ServiceGridProvider;
 use Sylius\Bundle\GridBundle\Registry\GridRegistryInterface;
 use Sylius\Component\Grid\Configuration\GridConfigurationExtender;
@@ -91,7 +93,6 @@ final class ServiceGridProviderTest extends TestCase
     {
         $fooGrid = $this->createMock(GridInterface::class);
         $fooFightersGrid = $this->createMock(GridInterface::class);
-        $fooGridDefinition = $this->createMock(Grid::class);
         $fooFightersGridDefinition = $this->createMock(Grid::class);
 
         $this->gridRegistry
@@ -111,6 +112,18 @@ final class ServiceGridProviderTest extends TestCase
         $this->converter->method('convert')->with('app_foo_fighters', $config)->willReturn($fooFightersGridDefinition);
 
         $this->assertSame($fooFightersGridDefinition, $this->provider->get('app_foo_fighters'));
+    }
+
+    public function testSupportsInvokableGrid(): void
+    {
+        $this->gridRegistry->method('getGrid')->with('app_book')->willReturn(new InvokableGrid(
+            function (GridBuilderInterface $gridBuilder): void {},
+            'app_book',
+        ));
+
+        $gridDefinition = $this->provider->get('app_book');
+
+        $this->assertInstanceOf(Grid::class, $gridDefinition);
     }
 
     public function testThrowsUndefinedGridExceptionWhenGridIsNotFound(): void

--- a/src/Component/GridInterface.php
+++ b/src/Component/GridInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid;
+
+/**
+ * @experimental
+ */
+interface GridInterface
+{
+    public function getName(): string;
+}

--- a/tests/Application/src/BoardGameBlog/Infrastructure/Sylius/Grid/BoardGameGrid.php
+++ b/tests/Application/src/BoardGameBlog/Infrastructure/Sylius/Grid/BoardGameGrid.php
@@ -16,19 +16,14 @@ namespace App\BoardGameBlog\Infrastructure\Sylius\Grid;
 use App\BoardGameBlog\Infrastructure\Sylius\Grid\DataProvider\BoardGameGridProvider;
 use Sylius\Bundle\GridBundle\Builder\Field\StringField;
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\AbstractGrid;
+use Sylius\Component\Grid\Attribute\AsGrid;
 
-final class BoardGameGrid extends AbstractGrid
+#[AsGrid(name: 'app_board_game', provider: BoardGameGridProvider::class)]
+final class BoardGameGrid
 {
-    public static function getName(): string
-    {
-        return 'app_board_game';
-    }
-
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
-            ->setProvider(BoardGameGridProvider::class)
             ->addField(
                 StringField::create('name')
                     ->setLabel('Name'),

--- a/tests/Application/src/Grid/AdminUserGrid.php
+++ b/tests/Application/src/Grid/AdminUserGrid.php
@@ -20,13 +20,12 @@ use Sylius\Bundle\GridBundle\Builder\Field\StringField;
 use Sylius\Bundle\GridBundle\Builder\Filter\EnumFilter;
 use Sylius\Bundle\GridBundle\Builder\Filter\Filter;
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\AbstractGrid;
 use Sylius\Component\Grid\Attribute\AsGrid;
 
 #[AsGrid(resourceClass: AdminUser::class, name: 'app_admin_user')]
-final class AdminUserGrid extends AbstractGrid
+final class AdminUserGrid
 {
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->addFilter(Filter::create('name', 'string'))

--- a/tests/Application/src/Grid/BookmarkGrid.php
+++ b/tests/Application/src/Grid/BookmarkGrid.php
@@ -16,22 +16,12 @@ namespace App\Grid;
 use App\Entity\Book;
 use Sylius\Bundle\GridBundle\Builder\Field\StringField;
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\AbstractGrid;
-use Sylius\Bundle\GridBundle\Grid\ResourceAwareGridInterface;
+use Sylius\Component\Grid\Attribute\AsGrid;
 
-final class BookmarkGrid extends AbstractGrid implements ResourceAwareGridInterface
+#[AsGrid(resourceClass: Book::class, name: 'app_bookmark')]
+final class BookmarkGrid
 {
-    public static function getName(): string
-    {
-        return 'app_bookmark';
-    }
-
-    public function getResourceClass(): string
-    {
-        return Book::class;
-    }
-
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->extends('app_book')


### PR DESCRIPTION
It replaces #461

Features:
- No more grid building logic inside the grid (the GridBuilder was created into the AbstractGrid)
- We can use any php grid with a simple "sylius.grid" tag 


**Before**
```php
<?php

declare(strict_types=1);

namespace App\Grid;

use App\Entity\Book;
use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
use Sylius\Bundle\GridBundle\Grid\AbstractGrid;
use Sylius\Component\Grid\Attribute\AsGrid;

#[AsGrid(resourceClass: Book::class, name: 'app_book')]
final class BookGrid extends AbstractGrid
{
    public function __invoke(GridBuilderInterface $gridBuilder): void
    {
    }
}

```

**After**
```php
<?php

declare(strict_types=1);

namespace App\Grid;

use App\Entity\Book;
use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
use Sylius\Component\Grid\Attribute\AsGrid;

#[AsGrid(resourceClass: Book::class, name: 'app_book')]
final class BookGrid
{
    public function __invoke(GridBuilderInterface $gridBuilder): void
    {
    }
}

```

TODO:
- [x] Deprecate the AbstractGrid class
- [x] Deprecate the Sylius\Bundle\GridBundle\Grid\GridInterface