### PR TITLE
feat(invokabke-grids): Rework the compiler pass

### DIFF
--- a/src/Bundle/DependencyInjection/Compiler/InvokableGridPass.php
+++ b/src/Bundle/DependencyInjection/Compiler/InvokableGridPass.php
@@ -19,18 +19,17 @@ use Sylius\Component\Grid\Attribute\AsGrid;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * Register an instance of AttributeGrid for each service using the
- * PHP attributes to declare Grids.
+ * Register an instance of InvokableGrid for each service using the
+ * PHP attributes to declare Grids, or using the "sylius.invokable_grid" tag.
  *
  * @internal
  */
-final class AttributeGridPass implements CompilerPassInterface
+final class InvokableGridPass implements CompilerPassInterface
 {
-    private const TAG = 'sylius.attribute_grid';
+    private const TAG = 'sylius.invokable_grid';
 
     /**
      * @param \ReflectionClass<AsGrid> $reflector
@@ -43,7 +42,6 @@ final class AttributeGridPass implements CompilerPassInterface
         }
 
         $definition->addTag(self::TAG, [
-            'class' => $class,
             'name' => $attribute->name ?? $class,
             'resourceClass' => $attribute->resourceClass,
             'buildMethod' => $attribute->buildMethod,
@@ -54,11 +52,10 @@ final class AttributeGridPass implements CompilerPassInterface
     public function process(ContainerBuilder $container): void
     {
         foreach ($container->findTaggedServiceIds(self::TAG, true) as $id => $tags) {
+            $class = $container->findDefinition($id)->getClass();
+
             /** @var array<string, string|null> $attribute */
             foreach ($tags as $attribute) {
-                /** @var string $class */
-                $class = $attribute['class'] ?? throw new LogicException(sprintf('"class" attribute not found on "sylius.grid" tag for "%s" service.', $id));
-
                 $name = $attribute['name'] ?? $class;
                 $resourceClass = $attribute['resourceClass'] ?? null;
                 $buildMethod = $attribute['buildMethod'] ?? null;

--- a/src/Bundle/DependencyInjection/SyliusGridExtension.php
+++ b/src/Bundle/DependencyInjection/SyliusGridExtension.php
@@ -16,7 +16,7 @@ namespace Sylius\Bundle\GridBundle\DependencyInjection;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Doctrine\Bundle\PHPCRBundle\DoctrinePHPCRBundle;
 use Sylius\Bundle\CurrencyBundle\SyliusCurrencyBundle;
-use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\AttributeGridPass;
+use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\InvokableGridPass;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 use Sylius\Bundle\GridBundle\SyliusGridBundle;
 use Sylius\Component\Grid\Annotation\AsGridFieldCallableService;
@@ -96,7 +96,7 @@ final class SyliusGridExtension extends Extension
             },
         );
 
-        $container->registerAttributeForAutoconfiguration(AsGrid::class, AttributeGridPass::autoconfigureFromAttribute(...));
+        $container->registerAttributeForAutoconfiguration(AsGrid::class, InvokableGridPass::autoconfigureFromAttribute(...));
 
         $container->registerAttributeForAutoconfiguration(
             AsField::class,

--- a/src/Bundle/SyliusGridBundle.php
+++ b/src/Bundle/SyliusGridBundle.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\GridBundle;
 
-use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\AttributeGridPass;
+use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\InvokableGridPass;
 use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\RegisterDriversPass;
 use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\RegisterFieldTypesPass;
 use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\RegisterFiltersPass;
@@ -39,7 +39,7 @@ final class SyliusGridBundle extends Bundle
         $container->addCompilerPass(new RegisterStubCommandsPass());
         $container->addCompilerPass(new RegisterTimezoneParameterPass());
         $container->addCompilerPass(new ValidateConfiguredGridDriversPass());
-        $container->addCompilerPass(new AttributeGridPass());
+        $container->addCompilerPass(new InvokableGridPass());
     }
 
     /**

--- a/src/Bundle/Tests/DependencyInjection/Compiler/InvokableGridPassTest.php
+++ b/src/Bundle/Tests/DependencyInjection/Compiler/InvokableGridPassTest.php
@@ -14,15 +14,14 @@ declare(strict_types=1);
 namespace Sylius\Bundle\GridBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
-use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\AttributeGridPass;
+use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\InvokableGridPass;
 use Sylius\Bundle\GridBundle\Grid\InvokableGrid;
 use Sylius\Component\Grid\Attribute\AsGrid;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Reference;
 
-final class AttributeGridPassTest extends TestCase
+final class InvokableGridPassTest extends TestCase
 {
     public function test_it_adds_attribute_grid_tag_when_autoconfiguring(): void
     {
@@ -37,7 +36,7 @@ final class AttributeGridPassTest extends TestCase
 
         $reflector = new \ReflectionClass(DummyGrid::class);
 
-        AttributeGridPass::autoconfigureFromAttribute(
+        InvokableGridPass::autoconfigureFromAttribute(
             $definition,
             $attribute,
             $reflector,
@@ -45,13 +44,12 @@ final class AttributeGridPassTest extends TestCase
 
         $this->assertSame([
             [
-                'class' => DummyGrid::class,
                 'name' => 'admin_product',
                 'resourceClass' => 'App\Entity\Product',
                 'buildMethod' => 'buildGrid',
                 'provider' => 'app.provider',
             ],
-        ], $definition->getTag('sylius.attribute_grid'));
+        ], $definition->getTag('sylius.invokable_grid'));
     }
 
     public function test_it_registers_invokable_grid_services(): void
@@ -59,16 +57,15 @@ final class AttributeGridPassTest extends TestCase
         $container = new ContainerBuilder();
 
         $container
-            ->register('app.grid')
-            ->addTag('sylius.attribute_grid', [
-                'class' => DummyGrid::class,
+            ->register('app.grid', DummyGrid::class)
+            ->addTag('sylius.invokable_grid', [
                 'name' => 'admin_product',
                 'resourceClass' => 'App\Entity\Product',
                 'buildMethod' => 'buildGrid',
                 'provider' => 'app.provider',
             ]);
 
-        $pass = new AttributeGridPass();
+        $pass = new InvokableGridPass();
 
         $pass->process($container);
 
@@ -92,20 +89,6 @@ final class AttributeGridPassTest extends TestCase
             ['name' => 'admin_product'],
             ['name' => DummyGrid::class],
         ], $definition->getTag('sylius.grid'));
-    }
-
-    public function test_it_throws_when_class_attribute_is_missing(): void
-    {
-        $container = new ContainerBuilder();
-
-        $container
-            ->register('app.grid')
-            ->addTag('sylius.attribute_grid', []);
-
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('"class" attribute not found on "sylius.grid" tag for "app.grid" service.');
-
-        (new AttributeGridPass())->process($container);
     }
 }
 


### PR DESCRIPTION
So on Sylius, it will be
` ->tag('sylius.invokable_grid', ['name' => 'sylius_admin_product'])`