### PR TITLE
Read grid metadata from #[AsGrid] attribute as invokable_grid tag fallback

### DIFF
--- a/src/Bundle/DependencyInjection/Compiler/InvokableGridPass.php
+++ b/src/Bundle/DependencyInjection/Compiler/InvokableGridPass.php
@@ -57,10 +57,10 @@ final class InvokableGridPass implements CompilerPassInterface
 
             /** @var array<string, string|null> $attribute */
             foreach ($tags as $attribute) {
-                $name = $attribute['name'] ?? $asGrid?->name ?? $class;
-                $resourceClass = $attribute['resourceClass'] ?? $asGrid?->resourceClass;
-                $buildMethod = $attribute['buildMethod'] ?? $asGrid?->buildMethod;
-                $provider = $attribute['provider'] ?? $asGrid?->provider;
+                $name = $attribute['name'] ?? $asGrid->name ?? $class;
+                $resourceClass = $attribute['resourceClass'] ?? $asGrid->resourceClass;
+                $buildMethod = $attribute['buildMethod'] ?? $asGrid->buildMethod;
+                $provider = $attribute['provider'] ?? $asGrid->provider;
 
                 $container->register('.sylius.grid.' . $id, InvokableGrid::class)
                     ->setArguments([new Reference($id), $name, $class, $resourceClass, $buildMethod, $provider])
@@ -71,15 +71,15 @@ final class InvokableGridPass implements CompilerPassInterface
         }
     }
 
-    private function resolveAsGrid(?string $class): ?AsGrid
+    private function resolveAsGrid(?string $class): AsGrid
     {
         // getClass() may be null or a "%parameter%" placeholder; only reflect real classes.
         if (null === $class || !class_exists($class)) {
-            return null;
+            return new AsGrid();
         }
 
         $attributes = (new \ReflectionClass($class))->getAttributes(AsGrid::class);
 
-        return ($attributes[0] ?? null)?->newInstance();
+        return ($attributes[0] ?? null)?->newInstance() ?? new AsGrid();
     }
 }

--- a/src/Bundle/DependencyInjection/Compiler/InvokableGridPass.php
+++ b/src/Bundle/DependencyInjection/Compiler/InvokableGridPass.php
@@ -53,13 +53,14 @@ final class InvokableGridPass implements CompilerPassInterface
     {
         foreach ($container->findTaggedServiceIds(self::TAG, true) as $id => $tags) {
             $class = $container->findDefinition($id)->getClass();
+            $asGrid = $this->resolveAsGrid($class);
 
             /** @var array<string, string|null> $attribute */
             foreach ($tags as $attribute) {
-                $name = $attribute['name'] ?? $class;
-                $resourceClass = $attribute['resourceClass'] ?? null;
-                $buildMethod = $attribute['buildMethod'] ?? null;
-                $provider = $attribute['provider'] ?? null;
+                $name = $attribute['name'] ?? $asGrid?->name ?? $class;
+                $resourceClass = $attribute['resourceClass'] ?? $asGrid?->resourceClass;
+                $buildMethod = $attribute['buildMethod'] ?? $asGrid?->buildMethod;
+                $provider = $attribute['provider'] ?? $asGrid?->provider;
 
                 $container->register('.sylius.grid.' . $id, InvokableGrid::class)
                     ->setArguments([new Reference($id), $name, $class, $resourceClass, $buildMethod, $provider])
@@ -68,5 +69,17 @@ final class InvokableGridPass implements CompilerPassInterface
                 ;
             }
         }
+    }
+
+    private function resolveAsGrid(?string $class): ?AsGrid
+    {
+        // getClass() may be null or a "%parameter%" placeholder; only reflect real classes.
+        if (null === $class || !class_exists($class)) {
+            return null;
+        }
+
+        $attributes = (new \ReflectionClass($class))->getAttributes(AsGrid::class);
+
+        return ($attributes[0] ?? null)?->newInstance();
     }
 }

--- a/src/Bundle/Tests/DependencyInjection/Compiler/InvokableGridPassTest.php
+++ b/src/Bundle/Tests/DependencyInjection/Compiler/InvokableGridPassTest.php
@@ -90,8 +90,71 @@ final class InvokableGridPassTest extends TestCase
             ['name' => DummyGrid::class],
         ], $definition->getTag('sylius.grid'));
     }
+
+    public function test_it_reads_metadata_from_as_grid_attribute_when_tag_has_no_name(): void
+    {
+        $container = new ContainerBuilder();
+
+        $container
+            ->register('app.grid', AttributedDummyGrid::class)
+            ->addTag('sylius.invokable_grid');
+
+        $pass = new InvokableGridPass();
+
+        $pass->process($container);
+
+        $definition = $container->getDefinition('.sylius.grid.app.grid');
+
+        $this->assertEquals([
+            new Reference('app.grid'),
+            'app_book',
+            AttributedDummyGrid::class,
+            'App\Entity\Book',
+            'build',
+            'app.book_provider',
+        ], $definition->getArguments());
+
+        $this->assertSame([
+            ['name' => 'app_book'],
+            ['name' => AttributedDummyGrid::class],
+        ], $definition->getTag('sylius.grid'));
+    }
+
+    public function test_tag_attributes_override_the_as_grid_attribute(): void
+    {
+        $container = new ContainerBuilder();
+
+        $container
+            ->register('app.grid', AttributedDummyGrid::class)
+            ->addTag('sylius.invokable_grid', ['name' => 'overridden']);
+
+        $pass = new InvokableGridPass();
+
+        $pass->process($container);
+
+        $definition = $container->getDefinition('.sylius.grid.app.grid');
+
+        $this->assertEquals([
+            new Reference('app.grid'),
+            'overridden',
+            AttributedDummyGrid::class,
+            'App\Entity\Book',
+            'build',
+            'app.book_provider',
+        ], $definition->getArguments());
+
+        $this->assertSame([
+            ['name' => 'overridden'],
+            ['name' => AttributedDummyGrid::class],
+        ], $definition->getTag('sylius.grid'));
+    }
 }
 
 final class DummyGrid
+{
+}
+
+#[AsGrid(resourceClass: 'App\Entity\Book', name: 'app_book', buildMethod: 'build', provider: 'app.book_provider')]
+final class AttributedDummyGrid
 {
 }


### PR DESCRIPTION
This makes `InvokableGridPass::process()` read grid metadata (`name`, `resourceClass`, `buildMethod`, `provider`) from the `#[AsGrid]` attribute on the service class, used as a fallback when not provided in the tag.

This lets an explicitly registered grid service drop the duplicated name from the tag:

Before
```php
->tag('sylius.invokable_grid', ['name' => 'app_book'])
```
After
```php
->tag('sylius.invokable_grid')
```

Backward compatible: a tag with name still wins and overrides the attribute.