### PR TITLE
feat(grid-builder): add withActions methods

### DIFF
--- a/src/Bundle/Builder/GridBuilder.php
+++ b/src/Bundle/Builder/GridBuilder.php
@@ -206,6 +206,35 @@ final class GridBuilder implements GridBuilderInterface
         return $this;
     }
 
+    public function withActions(string $group, ActionInterface ...$actions): self
+    {
+        foreach ($actions as $action) {
+            $this->addAction($action, $group);
+        }
+
+        return $this;
+    }
+
+    public function withMainActions(ActionInterface ...$actions): self
+    {
+        return $this->withActions(ActionGroupInterface::MAIN_GROUP, ...$actions);
+    }
+
+    public function withItemActions(ActionInterface ...$actions): self
+    {
+        return $this->withActions(ActionGroupInterface::ITEM_GROUP, ...$actions);
+    }
+
+    public function withSubItemActions(ActionInterface ...$actions): self
+    {
+        return $this->withActions(ActionGroupInterface::SUB_ITEM_GROUP, ...$actions);
+    }
+
+    public function withBulkActions(ActionInterface ...$actions): self
+    {
+        return $this->withActions(ActionGroupInterface::BULK_GROUP, ...$actions);
+    }
+
     public function removeAction(string $name, string $group): self
     {
         $actionGroup = $this->actionGroups[$group] ?? null;

--- a/src/Bundle/Builder/GridBuilderInterface.php
+++ b/src/Bundle/Builder/GridBuilderInterface.php
@@ -23,6 +23,11 @@ use Sylius\Bundle\GridBundle\Builder\Filter\FilterInterface;
  * @method GridBuilderInterface setProvider(string|callable|null $provider)
  * @method GridBuilderInterface withFields(FieldInterface ...$fields)
  * @method GridBuilderInterface withFilters(FilterInterface ...$filters)
+ * @method GridBuilderInterface withActions(string $group, ActionInterface ...$actions)
+ * @method GridBuilderInterface withMainActions(ActionInterface ...$actions)
+ * @method GridBuilderInterface withItemActions(ActionInterface ...$actions)
+ * @method GridBuilderInterface withSubItemActions(ActionInterface ...$actions)
+ * @method GridBuilderInterface withBulkActions(ActionInterface ...$actions)
  *
  * @psalm-method string|callable|null getProvider()
  * @psalm-method GridBuilderInterface setProvider(string|callable|null $provider)

--- a/src/Bundle/Tests/Unit/Builder/GridBuilderTest.php
+++ b/src/Bundle/Tests/Unit/Builder/GridBuilderTest.php
@@ -219,6 +219,51 @@ final class GridBuilderTest extends TestCase
         $this->assertSame('sylius.ui.edit', $this->gridBuilder->toArray()['actions'][ActionGroupInterface::ITEM_GROUP]['update']['label']);
     }
 
+    public function testWithActions(): void
+    {
+        $this->gridBuilder->withActions(ActionGroupInterface::MAIN_GROUP, CreateAction::create());
+        $this->gridBuilder->withActions(ActionGroupInterface::ITEM_GROUP, UpdateAction::create());
+
+        $this->assertArrayHasKey(ActionGroupInterface::MAIN_GROUP, $this->gridBuilder->toArray()['actions']);
+        $this->assertArrayHasKey(ActionGroupInterface::ITEM_GROUP, $this->gridBuilder->toArray()['actions']);
+        $this->assertArrayHasKey('create', $this->gridBuilder->toArray()['actions'][ActionGroupInterface::MAIN_GROUP]);
+        $this->assertArrayHasKey('update', $this->gridBuilder->toArray()['actions'][ActionGroupInterface::ITEM_GROUP]);
+    }
+
+    public function testWithMainActions(): void
+    {
+        $this->gridBuilder->withMainActions(CreateAction::create());
+
+        $this->assertArrayHasKey(ActionGroupInterface::MAIN_GROUP, $this->gridBuilder->toArray()['actions']);
+        $this->assertArrayHasKey('create', $this->gridBuilder->toArray()['actions'][ActionGroupInterface::MAIN_GROUP]);
+    }
+
+    public function testWithItemActions(): void
+    {
+        $this->gridBuilder->withItemActions(UpdateAction::create(), DeleteAction::create());
+
+        $this->assertArrayHasKey(ActionGroupInterface::ITEM_GROUP, $this->gridBuilder->toArray()['actions']);
+        $this->assertArrayHasKey('update', $this->gridBuilder->toArray()['actions'][ActionGroupInterface::ITEM_GROUP]);
+        $this->assertArrayHasKey('delete', $this->gridBuilder->toArray()['actions'][ActionGroupInterface::ITEM_GROUP]);
+    }
+
+    public function testWithSubItemActions(): void
+    {
+        $this->gridBuilder->withSubItemActions(UpdateAction::create(), DeleteAction::create());
+
+        $this->assertArrayHasKey(ActionGroupInterface::SUB_ITEM_GROUP, $this->gridBuilder->toArray()['actions']);
+        $this->assertArrayHasKey('update', $this->gridBuilder->toArray()['actions'][ActionGroupInterface::SUB_ITEM_GROUP]);
+        $this->assertArrayHasKey('delete', $this->gridBuilder->toArray()['actions'][ActionGroupInterface::SUB_ITEM_GROUP]);
+    }
+
+    public function testWithBulkActions(): void
+    {
+        $this->gridBuilder->withBulkActions(DeleteAction::create());
+
+        $this->assertArrayHasKey(ActionGroupInterface::BULK_GROUP, $this->gridBuilder->toArray()['actions']);
+        $this->assertArrayHasKey('delete', $this->gridBuilder->toArray()['actions'][ActionGroupInterface::BULK_GROUP]);
+    }
+
     public function testAddsUpdateActionsOnASpecificGroup(): void
     {
         $this->gridBuilder->addAction(UpdateAction::create(), 'custom');

--- a/tests/Application/src/Grid/BookGrid.php
+++ b/tests/Application/src/Grid/BookGrid.php
@@ -17,7 +17,6 @@ use App\Entity\Author;
 use App\Entity\Book;
 use App\Grid\Builder\NationalityFilter;
 use Sylius\Bundle\GridBundle\Builder\Action\ShowAction;
-use Sylius\Bundle\GridBundle\Builder\ActionGroup\ItemActionGroup;
 use Sylius\Bundle\GridBundle\Builder\Field\CallableField;
 use Sylius\Bundle\GridBundle\Builder\Field\StringField;
 use Sylius\Bundle\GridBundle\Builder\Filter\Filter;
@@ -71,11 +70,9 @@ final class BookGrid extends AbstractGrid
                     ->setSortable(true, 'price.currencyCode')
                     ->setOption('vars', ['th_class' => 'text-end']),
             )
-            ->addActionGroup(
-                ItemActionGroup::create(
-                    ShowAction::create()
-                        ->setTemplate('book/grid/action/show.html.twig'),
-                ),
+            ->withItemActions(
+                ShowAction::create()
+                    ->setTemplate('book/grid/action/show.html.twig'),
             )
             ->setLimits([10, 5, 15])
         ;


### PR DESCRIPTION
In continuation of `withFields` and `withFilters` helpers.

This PR adds these following method:
- withActions
- withMainActions
- withItemActions
- withSubItemActions
- withBulkActions