### PR TITLE
feat(php-grids): Grid mutators

### DIFF
--- a/src/Bundle/DependencyInjection/Compiler/GridMutatorPass.php
+++ b/src/Bundle/DependencyInjection/Compiler/GridMutatorPass.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\GridBundle\DependencyInjection\Compiler;
+
+use Sylius\Component\Grid\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class GridMutatorPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('sylius.grid.mutator_collection')) {
+            return;
+        }
+
+        $definition = $container->getDefinition('sylius.grid.mutator_collection');
+
+        /** @var list<array{id: string, grid: string, priority: int}> $mutators */
+        $mutators = [];
+
+        foreach ($container->findTaggedServiceIds('sylius.grid_mutator') as $id => $attributes) {
+            /**
+             * @var array{grid?: ?string, priority?: ?int} $attribute
+             */
+            foreach ($attributes as $attribute) {
+                $grid = $attribute['grid'] ?? throw new LogicException('The "sylius.grid_mutator" tag should have a "grid" attribute');
+
+                $mutators[] = ['id' => $id, 'grid' => $grid, 'priority' => $attribute['priority'] ?? 0];
+            }
+        }
+
+        uasort($mutators, static fn (array $a, array $b): int => $b['priority'] <=> $a['priority']);
+
+        foreach ($mutators as $mutator) {
+            $definition->addMethodCall('add', [
+                $mutator['grid'],
+                new Reference($mutator['id']),
+            ]);
+        }
+    }
+}

--- a/src/Bundle/DependencyInjection/SyliusGridExtension.php
+++ b/src/Bundle/DependencyInjection/SyliusGridExtension.php
@@ -23,11 +23,14 @@ use Sylius\Component\Grid\Annotation\AsGridFieldCallableService;
 use Sylius\Component\Grid\Attribute\AsField;
 use Sylius\Component\Grid\Attribute\AsFilter;
 use Sylius\Component\Grid\Attribute\AsGrid;
+use Sylius\Component\Grid\Attribute\AsGridMutator;
 use Sylius\Component\Grid\Data\DataProviderInterface;
 use Sylius\Component\Grid\Filtering\ConfigurableFilterInterface;
+use Sylius\Component\Grid\Mutator\GridMutatorInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Twig\Environment;
@@ -103,6 +106,20 @@ final class SyliusGridExtension extends Extension
             static function (ChildDefinition $definition, AsField $attribute, \ReflectionClass $reflector): void {
                 $definition->addTag(AsField::SERVICE_TAG, [
                     'type' => $attribute->type ?? $reflector->getName(),
+                ]);
+            },
+        );
+
+        $container->registerAttributeForAutoconfiguration(
+            AsGridMutator::class,
+            static function (ChildDefinition $definition, AsGridMutator $attribute, \ReflectionClass $reflector): void {
+                if (!is_a($reflector->name, GridMutatorInterface::class, true)) {
+                    throw new RuntimeException(\sprintf('Grid mutator "%s" should implement %s', $reflector->name, GridMutatorInterface::class));
+                }
+
+                $definition->addTag('sylius.grid_mutator', [
+                    'grid' => $attribute->grid,
+                    'priority' => $attribute->priority,
                 ]);
             },
         );

--- a/src/Bundle/Provider/ServiceGridProvider.php
+++ b/src/Bundle/Provider/ServiceGridProvider.php
@@ -27,6 +27,8 @@ use Sylius\Component\Grid\Definition\Grid;
 use Sylius\Component\Grid\Exception\LogicException;
 use Sylius\Component\Grid\Exception\UndefinedGridException;
 use Sylius\Component\Grid\GridInterface;
+use Sylius\Component\Grid\Mutator\GridMutatorCollection;
+use Sylius\Component\Grid\Mutator\GridMutatorCollectionInterface;
 use Sylius\Component\Grid\Provider\GridProviderInterface;
 use Webmozart\Assert\Assert;
 
@@ -42,18 +44,22 @@ final class ServiceGridProvider implements GridProviderInterface
 
     private GridConfigurationSortingHandlerInterface $gridConfigurationSortingHandler;
 
+    private GridMutatorCollectionInterface $gridMutatorCollection;
+
     public function __construct(
         ArrayToDefinitionConverterInterface $converter,
         GridRegistryInterface $gridRegistry,
         GridConfigurationExtenderInterface $gridConfigurationExtender,
         ?GridConfigurationRemovalsHandlerInterface $gridConfigurationRemovalsHandler = null,
         ?GridConfigurationSortingHandlerInterface $gridConfigurationSortingHandler = null,
+        ?GridMutatorCollectionInterface $gridMutatorCollection = null,
     ) {
         $this->converter = $converter;
         $this->gridRegistry = $gridRegistry;
         $this->gridConfigurationExtender = $gridConfigurationExtender;
         $this->gridConfigurationRemovalsHandler = $gridConfigurationRemovalsHandler ?? new GridConfigurationRemovalsHandler();
         $this->gridConfigurationSortingHandler = $gridConfigurationSortingHandler ?? new GridConfigurationSortingHandler();
+        $this->gridMutatorCollection = $gridMutatorCollection ?? new GridMutatorCollection();
     }
 
     public function get(string $code): Grid
@@ -118,6 +124,10 @@ final class ServiceGridProvider implements GridProviderInterface
         }
 
         $grid($gridBuilder);
+
+        foreach ($this->gridMutatorCollection->get($grid->getName()) as $mutator) {
+            ($mutator)($gridBuilder);
+        }
 
         return $gridBuilder->toArray();
     }

--- a/src/Bundle/Resources/config/services.php
+++ b/src/Bundle/Resources/config/services.php
@@ -42,6 +42,7 @@ use Sylius\Component\Grid\Filtering\FiltersApplicator;
 use Sylius\Component\Grid\Filtering\FiltersApplicatorInterface;
 use Sylius\Component\Grid\Filtering\FiltersCriteriaResolver;
 use Sylius\Component\Grid\Filtering\FiltersCriteriaResolverInterface;
+use Sylius\Component\Grid\Mutator\GridMutatorCollection;
 use Sylius\Component\Grid\Provider\ArrayGridProvider;
 use Sylius\Component\Grid\Provider\ChainProvider;
 use Sylius\Component\Grid\Provider\GridProviderInterface;
@@ -113,6 +114,7 @@ return static function (ContainerConfigurator $container) {
             service('sylius.grid.configuration_extender'),
             service('sylius.grid.configuration_removals_handler'),
             service('sylius.grid.configuration_sorting_handler'),
+            service('sylius.grid.mutator_collection'),
         ])
         ->tag('sylius.grid_provider', ['key' => 'service', 'priority' => -100]);
 
@@ -213,5 +215,8 @@ return static function (ContainerConfigurator $container) {
         ->private();
 
     $services->alias(OptionsParserInterface::class, 'sylius.grid.options_parser')
+        ->private();
+
+    $services->set('sylius.grid.mutator_collection', GridMutatorCollection::class)
         ->private();
 };

--- a/src/Bundle/SyliusGridBundle.php
+++ b/src/Bundle/SyliusGridBundle.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\GridBundle;
 
+use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\GridMutatorPass;
 use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\InvokableGridPass;
 use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\RegisterDriversPass;
 use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\RegisterFieldTypesPass;
@@ -40,6 +41,7 @@ final class SyliusGridBundle extends Bundle
         $container->addCompilerPass(new RegisterTimezoneParameterPass());
         $container->addCompilerPass(new ValidateConfiguredGridDriversPass());
         $container->addCompilerPass(new InvokableGridPass());
+        $container->addCompilerPass(new GridMutatorPass());
     }
 
     /**

--- a/src/Bundle/Tests/DependencyInjection/Compiler/GridMutatorPassTest.php
+++ b/src/Bundle/Tests/DependencyInjection/Compiler/GridMutatorPassTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\GridBundle\Tests\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\GridMutatorPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class GridMutatorPassTest extends AbstractCompilerPassTestCase
+{
+    public function testItDoesNothingWhenGridMutatorCollectionDoesNotExist(): void
+    {
+        $this->compile();
+
+        $this->assertContainerBuilderNotHasService('sylius.grid.mutator_collection');
+    }
+
+    public function testItDoesNothingWhenOperationMutatorCollectionDoesNotExist(): void
+    {
+        $this->compile();
+
+        $this->assertContainerBuilderNotHasService('sylius.grid.mutator_collection');
+    }
+
+    public function testItAddsResourceMutatorsToCollection(): void
+    {
+        $mutatorCollectionDefinition = new Definition();
+        $this->setDefinition('sylius.grid.mutator_collection', $mutatorCollectionDefinition);
+
+        $mutatorDefinition = new Definition();
+        $mutatorDefinition->addTag('sylius.grid_mutator', ['grid' => 'app_book']);
+        $this->setDefinition('app.grid_mutator.book', $mutatorDefinition);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sylius.grid.mutator_collection',
+            'add',
+            [
+                'app_book',
+                new Reference('app.grid_mutator.book'),
+            ],
+        );
+    }
+
+    public function testItAddsMultipleGridMutatorsToCollection(): void
+    {
+        $mutatorCollectionDefinition = new Definition();
+        $this->setDefinition('sylius.grid.mutator_collection', $mutatorCollectionDefinition);
+
+        $productMutatorDefinition = new Definition();
+        $productMutatorDefinition->addTag('sylius.grid_mutator', ['grid' => 'app_product']);
+        $this->setDefinition('app.grid_mutator.product', $productMutatorDefinition);
+
+        $customerMutatorDefinition = new Definition();
+        $customerMutatorDefinition->addTag('sylius.grid_mutator', ['grid' => 'app_customer']);
+        $this->setDefinition('app.grid_mutator.customer', $customerMutatorDefinition);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sylius.grid.mutator_collection',
+            'add',
+            [
+                'app_product',
+                new Reference('app.grid_mutator.product'),
+            ],
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sylius.grid.mutator_collection',
+            'add',
+            [
+                'app_customer',
+                new Reference('app.grid_mutator.customer'),
+            ],
+        );
+    }
+
+    public function testItSortsMutatorsByTheirPriority(): void
+    {
+        $mutatorCollectionDefinition = new Definition();
+        $this->setDefinition('sylius.grid.mutator_collection', $mutatorCollectionDefinition);
+
+        $productMutatorDefinition = new Definition();
+        $productMutatorDefinition->addTag('sylius.grid_mutator', ['grid' => 'app_product']);
+        $this->setDefinition('app.grid_mutator.product', $productMutatorDefinition);
+
+        $customerMutatorDefinition = new Definition();
+        $customerMutatorDefinition->addTag('sylius.grid_mutator', ['grid' => 'app_customer', 'priority' => 10]);
+        $this->setDefinition('app.grid_mutator.customer', $customerMutatorDefinition);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sylius.grid.mutator_collection',
+            'add',
+            [
+                'app_customer',
+                new Reference('app.grid_mutator.customer'),
+            ],
+            index: 0, // It has been registered first
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sylius.grid.mutator_collection',
+            'add',
+            [
+                'app_product',
+                new Reference('app.grid_mutator.product'),
+            ],
+            index: 1, // It has been registered after app.grid_mutator.customer
+        );
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new GridMutatorPass());
+    }
+}

--- a/src/Bundle/Tests/Functional/GridUiTest.php
+++ b/src/Bundle/Tests/Functional/GridUiTest.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\GridBundle\Tests\Functional;
 
 use App\Factory\AuthorFactory;
 use App\Story\AppStory;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DomCrawler\Crawler;
@@ -74,7 +75,7 @@ final class GridUiTest extends WebTestCase
         $this->assertContains('', $nationalities);
     }
 
-    /** @test */
+    #[Test]
     public function it_sorts_authors_by_name_ascending_by_default(): void
     {
         $this->client->request('GET', '/authors?limit=100');
@@ -87,7 +88,7 @@ final class GridUiTest extends WebTestCase
         $this->assertSame($sortedNames, $names);
     }
 
-    /** @test */
+    #[Test]
     public function it_sorts_authors_by_name_descending(): void
     {
         $this->client->request('GET', '/authors?sorting[name]=desc&limit=100');
@@ -315,6 +316,19 @@ final class GridUiTest extends WebTestCase
         $this->assertContains('enum.status.banned', $statuses);
     }
 
+    #[Test]
+    public function it_sorts_board_games_by_name_ascending_by_default(): void
+    {
+        $this->client->request('GET', '/board-games?limit=100');
+
+        $names = $this->getBoardGameNamesFromResponse();
+
+        $sortedNames = $names;
+        sort($names);
+
+        $this->assertSame($sortedNames, $names);
+    }
+
     /** @return string[] */
     private function getBookTitlesFromResponse(): array
     {
@@ -380,6 +394,16 @@ final class GridUiTest extends WebTestCase
     {
         return $this->getCrawler()
             ->filter('[data-test-status]')
+            ->each(
+                fn (Crawler $node): string => $node->text(),
+            );
+    }
+
+    /** @return string[] */
+    private function getBoardGameNamesFromResponse(): array
+    {
+        return $this->getCrawler()
+            ->filter('[data-test-name]')
             ->each(
                 fn (Crawler $node): string => $node->text(),
             );

--- a/src/Component/Attribute/AsGridMutator.php
+++ b/src/Component/Attribute/AsGridMutator.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+final class AsGridMutator
+{
+    public function __construct(
+        public readonly string $grid,
+        public readonly ?int $priority = null,
+    ) {
+    }
+}

--- a/src/Component/Mutator/GridMutatorCollection.php
+++ b/src/Component/Mutator/GridMutatorCollection.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Mutator;
+
+/**
+ * @internal
+ */
+final class GridMutatorCollection implements GridMutatorCollectionInterface
+{
+    /** @var array<string, list<GridMutatorInterface>> */
+    private array $mutators = [];
+
+    public function add(string $grid, GridMutatorInterface $mutator): void
+    {
+        $this->mutators[$grid][] = $mutator;
+    }
+
+    public function get(string $id): array
+    {
+        return $this->mutators[$id] ?? [];
+    }
+
+    public function has(string $id): bool
+    {
+        return isset($this->mutators[$id]);
+    }
+}

--- a/src/Component/Mutator/GridMutatorCollectionInterface.php
+++ b/src/Component/Mutator/GridMutatorCollectionInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Mutator;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * Collection of Grid mutators to mutate Grid definitions.
+ *
+ * @experimental
+ */
+interface GridMutatorCollectionInterface extends ContainerInterface
+{
+    /**
+     * @return list<GridMutatorInterface>
+     */
+    public function get(string $id): array;
+}

--- a/src/Component/Mutator/GridMutatorInterface.php
+++ b/src/Component/Mutator/GridMutatorInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Grid\Mutator;
+
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
+
+interface GridMutatorInterface
+{
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
+}

--- a/tests/Application/src/BoardGameBlog/Infrastructure/Sylius/Grid/DataProvider/BoardGameGridProvider.php
+++ b/tests/Application/src/BoardGameBlog/Infrastructure/Sylius/Grid/DataProvider/BoardGameGridProvider.php
@@ -31,6 +31,9 @@ final class BoardGameGridProvider implements DataProviderInterface
     {
         $data = [];
 
+        /** @var array<string, string> $sorting */
+        $sorting = $parameters->get('sorting', $grid->getSorting());
+
         foreach ($this->getFileData() as $row) {
             [$id, $name, $shortDescription] = str_getcsv($row);
 
@@ -43,6 +46,14 @@ final class BoardGameGridProvider implements DataProviderInterface
                 name: $name,
                 shortDescription: $shortDescription,
             );
+        }
+
+        if ('asc' === ($sorting['name'] ?? null)) {
+            usort($data, fn (BoardGame $a, BoardGame $b) => $a->name <=> $b->name);
+        }
+
+        if ('desc' === ($sorting['name'] ?? null)) {
+            usort($data, fn (BoardGame $a, BoardGame $b) => $b->name <=> $a->name);
         }
 
         return new Pagerfanta(new ArrayAdapter($data));

--- a/tests/Application/src/BoardGameBlog/Infrastructure/Sylius/Grid/Mutator/SortByNameBookGridMutator.php
+++ b/tests/Application/src/BoardGameBlog/Infrastructure/Sylius/Grid/Mutator/SortByNameBookGridMutator.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App\BoardGameBlog\Infrastructure\Sylius\Grid\Mutator;
+
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
+use Sylius\Component\Grid\Attribute\AsGridMutator;
+use Sylius\Component\Grid\Mutator\GridMutatorInterface;
+
+#[AsGridMutator(grid: 'app_board_game')]
+class SortByNameBookGridMutator implements GridMutatorInterface
+{
+    public function __invoke(GridBuilderInterface $gridBuilder): void
+    {
+        $gridBuilder->orderBy('name', 'asc');
+    }
+}


### PR DESCRIPTION
Example:
```php
<?php

declare(strict_types=1);

namespace App\Grid;

use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
use Sylius\Component\Grid\Attribute\AsGridMutator;
use Sylius\Component\Grid\Mutator\GridMutatorInterface;

#[AsGridMutator(grid: 'sylius_admin_product')]
final class OrderByNameProductGridMutator implements GridMutatorInterface
{
    public function __invoke(GridBuilderInterface $gridBuilder): void
    {
        $gridBuilder->orderBy('name', 'desc');
        $gridBuilder->removeField('code');
    }
}
```

With a priority:

```php
<?php

declare(strict_types=1);

namespace App\Grid;

use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
use Sylius\Component\Grid\Attribute\AsGridMutator;
use Sylius\Component\Grid\Mutator\GridMutatorInterface;

#[AsGridMutator(grid: 'sylius_admin_product', priority: 20)]
final class RemoveImageProductGridMutator implements GridMutatorInterface
{
    public function __invoke(GridBuilderInterface $gridBuilder): void
    {
        $gridBuilder->removeField('image');
    }
}
```

